### PR TITLE
Implement Swift build function

### DIFF
--- a/app/routes/build_route.py
+++ b/app/routes/build_route.py
@@ -1,9 +1,21 @@
 from fastapi import APIRouter
+from pydantic import BaseModel
 from app.services.build import test_build
 
 router = APIRouter()
 
+class BuildRequest(BaseModel):
+    swift: str
+    output_binary: bool = False
+
+
 @router.post("/test-build")
-async def build(swift: str):
-    success, log = test_build(swift)
+async def build(req: BuildRequest):
+    result = test_build(req.swift, output_binary=req.output_binary)
+
+    if req.output_binary and result[0]:
+        success, log, artifact = result  # type: ignore[misc]
+        return {"success": success, "log": log, "artifact": artifact}
+
+    success, log = result[:2]
     return {"success": success, "log": log}

--- a/app/services/build.py
+++ b/app/services/build.py
@@ -1,3 +1,72 @@
-# service/build.py
-def test_build(swift: str) -> tuple[bool, str]:
-    return True, "Build succeeded (stub)."
+"""Utilities for compiling Swift code snippets."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import tempfile
+from typing import Tuple, Union
+
+
+def test_build(swift: str, output_binary: bool = False) -> Union[Tuple[bool, str], Tuple[bool, str, str]]:
+    """Compile Swift source code using ``swiftc``.
+
+    Parameters
+    ----------
+    swift:
+        Swift source code to compile.
+    output_binary:
+        If ``True`` and compilation succeeds, the path to the compiled binary
+        is returned as a third tuple element.
+
+    Returns
+    -------
+    Tuple
+        ``(success, log)`` or ``(success, log, artifact_path)`` when
+        ``output_binary`` is ``True`` and the compilation succeeded.
+    """
+
+    # Create temporary files for the Swift source and the resulting binary.
+    src_fd, src_path = tempfile.mkstemp(suffix=".swift")
+    bin_fd, bin_path = tempfile.mkstemp()
+
+    try:
+        with os.fdopen(src_fd, "w") as f:
+            f.write(swift)
+
+        os.close(bin_fd)  # close so swiftc can write the file
+
+        try:
+            result = subprocess.run(
+                ["swiftc", src_path, "-o", bin_path, "--emit-executable"],
+                capture_output=True,
+                text=True,
+            )
+            log = f"{result.stdout}{result.stderr}"
+            success = result.returncode == 0
+        except FileNotFoundError as e:
+            # swiftc not available
+            success = False
+            log = str(e)
+
+    finally:
+        # Source file is always removed
+        try:
+            os.remove(src_path)
+        except OSError:
+            pass
+
+        # Remove binary if caller doesn't want it or compilation failed
+        if not output_binary or not success:
+            try:
+                os.remove(bin_path)
+            except OSError:
+                pass
+
+    if output_binary and success:
+        return success, log, bin_path
+
+    return success, log
+
+# Prevent pytest from treating this function as a test case when imported.
+test_build.__test__ = False

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -1,0 +1,37 @@
+import os
+import subprocess
+from app.services.build import test_build
+
+
+def test_test_build_success(monkeypatch):
+    def fake_run(cmd, capture_output, text):
+        # create dummy binary file
+        out_index = cmd.index('-o') + 1
+        with open(cmd[out_index], 'w') as f:
+            f.write('binary')
+        class Result:
+            returncode = 0
+            stdout = 'ok'
+            stderr = ''
+        return Result()
+
+    monkeypatch.setattr(subprocess, 'run', fake_run)
+    success, log, artifact = test_build('print("hi")', output_binary=True)
+    assert success
+    assert 'ok' in log
+    assert os.path.exists(artifact)
+    os.remove(artifact)
+
+
+def test_test_build_failure(monkeypatch):
+    def fake_run(cmd, capture_output, text):
+        class Result:
+            returncode = 1
+            stdout = ''
+            stderr = 'error'
+        return Result()
+
+    monkeypatch.setattr(subprocess, 'run', fake_run)
+    success, log = test_build('bad swift')
+    assert not success
+    assert 'error' in log


### PR DESCRIPTION
## Summary
- flesh out build API to compile Swift source
- update route handler to support optional binary return
- add tests covering successful and failing builds

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68635362f1d08325a1490715a44eb913