### PR TITLE
Add optional metadata fields to LayoutNode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,6 +44,8 @@ ruff_cache/
 *.swift
 *.json
 *.bin
+# Allow committed example JSON files
+!examples/*.layout.json
 
 # Ignore generated UI files if any
 generated_ui/

--- a/api/openapi.yml
+++ b/api/openapi.yml
@@ -149,7 +149,15 @@ components:
       properties:
         id:
           type: string
-          description: Optional unique identifier for node
+          description: A unique node identifier
+        role:
+          type: string
+          description: Semantic role (e.g., "header", "submit")
+          nullable: true
+        tag:
+          type: string
+          description: Developer hint or custom logic
+          nullable: true
         type:
           type: string
           description: SwiftUI component type

--- a/app/models/layout.py
+++ b/app/models/layout.py
@@ -3,6 +3,11 @@ from typing import Optional, List
 
 
 class LayoutNode(BaseModel):
+    """Node in a layout tree."""
+
+    id: Optional[str] = None
+    role: Optional[str] = None
+    tag: Optional[str] = None
     type: str
     text: Optional[str] = None
     children: Optional[List['LayoutNode']] = None

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,3 +1,5 @@
 # Example: mockup1
 
-Simple vertical layout with a welcome text, logo image, and button.
+Simple vertical layout with a welcome text, logo image, and button. The
+corresponding layout JSON is provided in `mockup1.layout.json` and illustrates
+use of optional `id`, `role`, and `tag` metadata fields.

--- a/examples/mockup1.layout.json
+++ b/examples/mockup1.layout.json
@@ -1,0 +1,10 @@
+{
+  "type": "VStack",
+  "id": "root",
+  "tag": "example",
+  "children": [
+    { "type": "Text", "text": "Welcome", "role": "header" },
+    { "type": "Image", "text": "logo" },
+    { "type": "Button", "text": "Get Started", "role": "submit" }
+  ]
+}


### PR DESCRIPTION
## Summary
- update OpenAPI spec for optional id, role and tag
- support metadata in LayoutNode model
- document metadata example
- include sample layout JSON
- allow committing example JSON in `.gitignore`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_68635a7eba9483258e0c0dc5f7bc12e1