### PR TITLE
Add layout metadata hooks

### DIFF
--- a/app/services/codegen.py
+++ b/app/services/codegen.py
@@ -50,6 +50,10 @@ def generate_swift(layout: LayoutNode) -> str:
         t = node.type
         out: List[str] = []
 
+        # Preserve node id in a comment when header comments are enabled
+        if include_header and node.id:
+            out.append(f"{space}// id: {node.id}")
+
         if t in {"VStack", "HStack", "ZStack", "ScrollView"}:
             out.append(f"{space}{t} {{")
             for child in node.children or []:
@@ -57,7 +61,10 @@ def generate_swift(layout: LayoutNode) -> str:
             out.append(f"{space}}}")
         elif t == "Text":
             content = escape(node.text or "")
-            out.append(f'{space}Text("{content}")')
+            line = f'{space}Text("{content}")'
+            if node.tag == "readOnly":
+                line += ".foregroundColor(.gray)"
+            out.append(line)
         elif t == "Image":
             name = escape(node.text or "")
             out.append(f'{space}Image("{name}")')
@@ -65,7 +72,10 @@ def generate_swift(layout: LayoutNode) -> str:
             out.append(f"{space}Spacer()")
         elif t == "Button":
             label = escape(node.text or "Button")
-            out.append(f'{space}Button("{label}") {{}}')
+            line = f'{space}Button("{label}") {{}}'
+            if node.role == "submit":
+                line += ".buttonStyle(.borderedProminent)"
+            out.append(line)
         else:
             # Fallback for unknown node types - emit as a call with children
             out.append(f"{space}{t} {{")

--- a/tests/test_codegen.py
+++ b/tests/test_codegen.py
@@ -22,3 +22,27 @@ def test_header_comment_included():
     layout = LayoutNode(type="Text", text="Hi")
     swift = generate_swift(layout)
     assert swift.splitlines()[0].startswith("// Generated")
+
+
+def test_button_role_submit():
+    layout = LayoutNode(type="Button", text="Save", role="submit")
+    swift = generate_swift(layout)
+    assert 'Button("Save") {}.buttonStyle(.borderedProminent)' in swift
+
+
+def test_text_readonly_tag():
+    layout = LayoutNode(type="Text", text="Readonly", tag="readOnly")
+    swift = generate_swift(layout)
+    assert 'Text("Readonly").foregroundColor(.gray)' in swift
+
+
+def test_id_comment_present():
+    layout = LayoutNode(type="Text", text="ID", id="node1")
+    swift = generate_swift(layout)
+    lines = swift.splitlines()
+    for i, line in enumerate(lines):
+        if 'Text("ID")' in line:
+            assert lines[i - 1].strip() == "// id: node1"
+            break
+    else:
+        assert False, "id comment missing"


### PR DESCRIPTION
## Summary
- enhance `generate_swift` to apply layout node metadata
  - prominent submit button style
  - gray text style for read-only labels
  - emit ID comments when header comments are enabled
- expand unit tests for metadata handling

## Testing
- `pytest tests/test_codegen.py -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_68635bf67bfc83258f6c3b16240f7d4f