### PR TITLE
Add conditional layout support

### DIFF
--- a/api/openapi.yml
+++ b/api/openapi.yml
@@ -161,7 +161,7 @@ components:
         type:
           type: string
           description: SwiftUI component type
-          enum: [VStack, HStack, Text, Image, Button, Spacer, ScrollView, ZStack]
+          enum: [VStack, HStack, Text, Image, Button, Spacer, ScrollView, ZStack, Conditional]
         text:
           type: string
           nullable: true
@@ -169,6 +169,16 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/LayoutNode'
+          nullable: true
+        condition:
+          type: string
+          description: Condition expression controlling the branch
+          nullable: true
+        then:
+          $ref: '#/components/schemas/LayoutNode'
+          nullable: true
+        else:
+          $ref: '#/components/schemas/LayoutNode'
           nullable: true
 
     ErrorResponse:

--- a/app/models/layout.py
+++ b/app/models/layout.py
@@ -11,6 +11,35 @@ class LayoutNode(BaseModel):
     type: str
     text: Optional[str] = None
     children: Optional[List['LayoutNode']] = None
+    # Conditional layout support
+    condition: Optional[str] = None
+    then: Optional['LayoutNode'] = None
+    else_: Optional['LayoutNode'] = None
+
+    def __init__(self, **data):
+        # Map reserved keyword 'else' to 'else_'
+        if 'else' in data and 'else_' not in data:
+            data['else_'] = data.pop('else')
+
+        children = data.get('children')
+        if isinstance(children, list):
+            data['children'] = [c if isinstance(c, LayoutNode) else LayoutNode(**c) for c in children]
+
+        then = data.get('then')
+        if isinstance(then, dict):
+            data['then'] = LayoutNode(**then)
+
+        else_branch = data.get('else_')
+        if isinstance(else_branch, dict):
+            data['else_'] = LayoutNode(**else_branch)
+
+        super().__init__(**data)
+
+    def dict(self, *args, **kwargs):
+        data = super().dict(*args, **kwargs)
+        if 'else_' in data:
+            data['else'] = data.pop('else_')
+        return data
 
 LayoutNode.update_forward_refs()
 

--- a/app/services/codegen.py
+++ b/app/services/codegen.py
@@ -76,6 +76,15 @@ def generate_swift(layout: LayoutNode) -> str:
             if node.role == "submit":
                 line += ".buttonStyle(.borderedProminent)"
             out.append(line)
+        elif t == "Conditional":
+            cond = node.condition or "false"
+            out.append(f"{space}if {cond} {{")
+            if node.then:
+                out.extend(render(node.then, depth + 1))
+            out.append(f"{space}}} else {{")
+            if getattr(node, 'else_', None):
+                out.extend(render(node.else_, depth + 1))
+            out.append(f"{space}}}")
         else:
             # Fallback for unknown node types - emit as a call with children
             out.append(f"{space}{t} {{")

--- a/tests/test_codegen.py
+++ b/tests/test_codegen.py
@@ -46,3 +46,17 @@ def test_id_comment_present():
             break
     else:
         assert False, "id comment missing"
+
+
+def test_conditional_node():
+    layout = LayoutNode(
+        type="Conditional",
+        condition="flag",
+        then=LayoutNode(type="Text", text="Yes"),
+        **{"else": LayoutNode(type="Text", text="No")}
+    )
+    swift = generate_swift(layout)
+    assert "if flag {" in swift
+    assert 'Text("Yes")' in swift
+    assert '} else {' in swift
+    assert 'Text("No")' in swift


### PR DESCRIPTION
## Summary
- expand LayoutNode schema with new conditional layout type
- implement conditional fields in LayoutNode model with aliasing logic
- update codegen to render `if` statements for conditional nodes
- test rendering of conditional nodes

## Testing
- `pytest tests/test_codegen.py -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_68635e6761dc8325a454570f77d1dbe0