### PR TITLE
Implement ZStack layout support

### DIFF
--- a/api/openapi.yml
+++ b/api/openapi.yml
@@ -179,6 +179,9 @@ components:
           items:
             $ref: '#/components/schemas/LayoutNode'
           nullable: true
+          description: >
+            Child layout nodes rendered inside container views. Multiple entries
+            are typically used for ``VStack``, ``HStack`` or ``ZStack`` groups.
         condition:
           type: string
           description: Condition expression controlling the branch

--- a/app/models/layout.py
+++ b/app/models/layout.py
@@ -23,6 +23,8 @@ class LayoutNode(BaseModel):
     tag: Optional[str] = None
     type: ComponentType
     text: Optional[str] = None
+    # Container types like ``VStack`` or ``ZStack`` may hold multiple child
+    # nodes.  Non-container elements generally omit this field.
     children: Optional[List['LayoutNode']] = None
     # Conditional layout support
     condition: Optional[str] = None

--- a/app/services/codegen.py
+++ b/app/services/codegen.py
@@ -54,8 +54,13 @@ def generate_swift(layout: LayoutNode) -> str:
         if include_header and node.id:
             out.append(f"{space}// id: {node.id}")
 
-        if t in {"VStack", "HStack", "ZStack"}:
+        if t in {"VStack", "HStack"}:
             out.append(f"{space}{t} {{")
+            for child in node.children or []:
+                out.extend(render(child, depth + 1))
+            out.append(f"{space}}}")
+        elif t == "ZStack":
+            out.append(f"{space}ZStack {{")
             for child in node.children or []:
                 out.extend(render(child, depth + 1))
             out.append(f"{space}}}")

--- a/examples/mockup5.layout.json
+++ b/examples/mockup5.layout.json
@@ -1,0 +1,7 @@
+{
+  "type": "ZStack",
+  "children": [
+    { "type": "Image", "text": "background" },
+    { "type": "Text", "text": "Overlay" }
+  ]
+}

--- a/examples/mockup5.readme.md
+++ b/examples/mockup5.readme.md
@@ -1,0 +1,3 @@
+# Example: mockup5
+
+Demonstrates layer-based layout using a simple ZStack.

--- a/tests/mockup5.test.py
+++ b/tests/mockup5.test.py
@@ -1,0 +1,14 @@
+import json
+from app.services.codegen import generate_swift
+from app.models.layout import LayoutNode
+
+
+def test_mockup5_zstack():
+    with open("examples/mockup5.layout.json") as f:
+        layout = LayoutNode(**json.load(f))
+
+    output = generate_swift(layout)
+
+    assert "ZStack" in output
+    assert 'Image("background")' in output
+    assert 'Text("Overlay")' in output

--- a/tests/test_codegen.py
+++ b/tests/test_codegen.py
@@ -60,3 +60,17 @@ def test_conditional_node():
     assert 'Text("Yes")' in swift
     assert '} else {' in swift
     assert 'Text("No")' in swift
+
+
+def test_zstack_node():
+    layout = LayoutNode(
+        type="ZStack",
+        children=[
+            LayoutNode(type="Image", text="background"),
+            LayoutNode(type="Text", text="Overlay"),
+        ],
+    )
+    swift = generate_swift(layout)
+    assert "ZStack {" in swift
+    assert 'Image("background")' in swift
+    assert 'Text("Overlay")' in swift


### PR DESCRIPTION
## Summary
- document container children in LayoutNode schema
- clarify children field in LayoutNode model
- add explicit rendering branch for ZStack in codegen
- add mockup5 ZStack example and docs
- test ZStack handling in codegen and flow

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_68636831ded483259dd242bc6fde4751