### PR TITLE
Fix CI missing dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ pydantic
 openai
 click
 pytest
+python-multipart


### PR DESCRIPTION
## 🧠 Summary
- add python-multipart as required by FastAPI

## ✅ Testing
- `pip install -r requirements.txt` *(fails: Tunnel connection failed)*
- `pytest -q` *(fails: could not find package fastapi)*

------
https://chatgpt.com/codex/tasks/task_e_686377ddc7dc832585ce2e85fa88e997