### PR TITLE
Add Docker support and docs

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+__pycache__/
+*.pyc
+.env
+.git/
+.DS_Store

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,18 @@
+FROM swift:5.10-jammy
+
+# Install Python and pip
+RUN apt-get update && \
+    apt-get install -y python3 python3-pip && \
+    rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+# Install Python dependencies first for caching
+COPY requirements.txt .
+RUN pip3 install --no-cache-dir -r requirements.txt
+
+# Copy the rest of the application
+COPY . /app
+
+ENTRYPOINT ["python3", "cli/vi.py"]
+CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,12 @@
+build:
+	docker build -t swiftui-factory .
+
+vi:
+	docker run --rm -v $(PWD):/app -e OPENAI_API_KEY=$(OPENAI_API_KEY) swiftui-factory
+
+mockup1:
+	make build
+	docker run --rm -v $(PWD):/app -e OPENAI_API_KEY=$(OPENAI_API_KEY) swiftui-factory interpret examples/mockup1.jpeg \
+	  | docker run --rm -i -v $(PWD):/app -e OPENAI_API_KEY=$(OPENAI_API_KEY) swiftui-factory generate - \
+	  | tee GeneratedView.swift \
+	  | docker run --rm -i -v $(PWD):/app -e OPENAI_API_KEY=$(OPENAI_API_KEY) swiftui-factory test -

--- a/README.md
+++ b/README.md
@@ -44,6 +44,27 @@ Visit http://localhost:8000/docs for interactive API docs.
 pytest
 ```
 
+## Docker Support
+Build the container image:
+
+```bash
+docker build -t swiftui-factory .
+```
+
+Run the CLI using Docker:
+
+```bash
+docker run --rm -v $PWD:/app -e OPENAI_API_KEY=... swiftui-factory interpret examples/mockup1.jpeg
+```
+
+Run the FastAPI server:
+
+```bash
+docker run -p 8000:8000 -e OPENAI_API_KEY=... swiftui-factory uvicorn app.main:app --host 0.0.0.0 --port 8000
+```
+
+See [USAGE.md](USAGE.md) for more details.
+
 ## ✅ CI
 - ![CI Status](https://github.com/yourname/SwiftUI-View-Factory/actions/workflows/ci.yml/badge.svg)
 - Python 3.11

--- a/USAGE.md
+++ b/USAGE.md
@@ -1,0 +1,33 @@
+# Usage
+
+## CLI
+Run CLI commands locally after installing dependencies:
+
+```bash
+pip install -r requirements.txt
+python cli/vi.py interpret path/to/mockup.png
+python cli/vi.py generate examples/mockup1.layout.json
+python cli/vi.py test GeneratedView.swift
+```
+
+## FastAPI
+Launch the API locally with Uvicorn:
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+uvicorn app.main:app --reload
+```
+
+## Running via Docker
+
+### CLI
+```bash
+docker run --rm -v $PWD:/app -e OPENAI_API_KEY=... swiftui-factory interpret examples/mockup1.jpeg
+```
+
+### FastAPI
+```bash
+docker run -p 8000:8000 -e OPENAI_API_KEY=... swiftui-factory uvicorn app.main:app --host 0.0.0.0 --port 8000
+```

--- a/tests/test_endpoints.py
+++ b/tests/test_endpoints.py
@@ -5,6 +5,16 @@ import pytest
 from fastapi.testclient import TestClient
 
 
+def test_openapi_schema_available():
+    """Ensure the OpenAPI schema is served."""
+    from app.main import app
+
+    client = TestClient(app)
+    response = client.get("/openapi.json")
+    assert response.status_code == 200
+    assert "paths" in response.json()
+
+
 def test_placeholder():
     assert True
 


### PR DESCRIPTION
## Summary
- create Dockerfile for CLI and API
- add make targets for Docker use
- document Docker usage in USAGE.md and README
- ignore build and secret files for Docker
- test that FastAPI exposes openapi.json

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pydantic')*

------
https://chatgpt.com/codex/tasks/task_e_686381c3d49083258e52ae07fe04db37