### PR TITLE
Add diagnostic output to example pair check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,9 +28,12 @@ jobs:
         run: |
           python - <<'PY'
           import os, glob, sys
+          print('Found layout files:', glob.glob('examples/*.layout.json'))
           missing=[]
           for layout in glob.glob('examples/*.layout.json'):
               base=layout[:-12]
+              print('Checking for:', base + '.swift', 'and', base + '.readme.md')
+              print('Exists:', os.path.exists(base + '.swift'), os.path.exists(base + '.readme.md'))
               if not (os.path.exists(base+'.swift') and os.path.exists(base+'.readme.md')):
                   missing.append(os.path.basename(base))
           if missing:


### PR DESCRIPTION
## Summary
- print the list of layout files in the example verification step
- show which matching Swift and readme files exist during the check

## Testing
- `pytest -vv`

------
https://chatgpt.com/codex/tasks/task_e_6863ec204fe48325a99023f7b3a1842f