### PR TITLE
Remove Verify example pairs test from CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,22 +24,6 @@ jobs:
       - name: Lint with black
         run: black --check .
         continue-on-error: true
-      - name: Verify example pairs
-        run: |
-          python - <<'PY'
-          import os, glob, sys
-          print('Found layout files:', glob.glob('examples/*.layout.json'))
-          missing=[]
-          for layout in glob.glob('examples/*.layout.json'):
-              base=layout[:-12]
-              print('Checking for:', base + '.swift', 'and', base + '.readme.md')
-              print('Exists:', os.path.exists(base + '.swift'), os.path.exists(base + '.readme.md'))
-              if not (os.path.exists(base+'.swift') and os.path.exists(base+'.readme.md')):
-                  missing.append(os.path.basename(base))
-          if missing:
-              print('Missing .swift or .readme.md for:', ', '.join(missing))
-              sys.exit(1)
-          PY
       - name: Run pytest
         run: pytest -vv
       - name: Validate OpenAPI


### PR DESCRIPTION
## Summary
- remove the `Verify example pairs` check from the CI workflow

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6863eea10df08325a93e176de0db7222