### PR TITLE
Add organized pytest suite

### DIFF
--- a/pydantic/__init__.py
+++ b/pydantic/__init__.py
@@ -4,7 +4,21 @@ class BaseModel:
             setattr(self, k, v)
 
     def dict(self, *args, **kwargs):
-        return self.__dict__
+        result = {}
+        for k, v in self.__dict__.items():
+            if hasattr(v, "dict"):
+                result[k] = v.dict(*args, **kwargs)
+            elif isinstance(v, list):
+                processed = []
+                for item in v:
+                    if hasattr(item, "dict"):
+                        processed.append(item.dict(*args, **kwargs))
+                    else:
+                        processed.append(item)
+                result[k] = processed
+            else:
+                result[k] = v
+        return result
 
     @classmethod
     def parse_obj(cls, obj):

--- a/tests/e2e/test_mockup1_flow_e2e.py
+++ b/tests/e2e/test_mockup1_flow_e2e.py
@@ -1,0 +1,47 @@
+import json
+import sys
+import types
+from pathlib import Path
+import subprocess
+
+from fastapi.testclient import TestClient
+from app.main import app
+
+
+def test_mockup1_full_flow(monkeypatch):
+    # prepare openai patch
+    if "openai" not in sys.modules:
+        sys.modules["openai"] = types.SimpleNamespace(api_key=None, ChatCompletion=types.SimpleNamespace())
+    import openai
+
+    layout_json = json.loads(Path("examples/mockup1.layout.json").read_text())
+
+    async def fake_acreate(*args, **kwargs):
+        return {"choices": [{"message": {"content": json.dumps({"structured": layout_json, "version": "layout-v1"})}}]}
+
+    monkeypatch.setattr(openai.ChatCompletion, "acreate", fake_acreate, raising=False)
+
+    def fake_run(cmd, capture_output, text):
+        class Result:
+            returncode = 0
+            stdout = "ok"
+            stderr = ""
+        return Result()
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    client = TestClient(app)
+    with Path("examples/mockup1.jpeg").open("rb") as f:
+        resp = client.post("/factory/interpret", files={"file": ("mockup1.jpeg", f, "image/jpeg")})
+    assert resp.status_code == 200
+    layout = resp.json()["structured"]
+
+    resp = client.post("/factory/generate", json=layout)
+    swift = resp.json()["swift"]
+
+    for snippet in ["Text(\"Welcome\")", "Image(\"logo\")", "Button(\"Get Started\")"]:
+        assert snippet in swift
+
+    resp = client.post("/factory/test-build", json={"swift": swift})
+    assert resp.status_code == 200
+    assert resp.json().get("success") is True

--- a/tests/integration/test_generate_route_integration.py
+++ b/tests/integration/test_generate_route_integration.py
@@ -1,0 +1,15 @@
+import json
+from pathlib import Path
+
+from fastapi.testclient import TestClient
+from app.main import app
+
+
+def test_generate_endpoint():
+    client = TestClient(app)
+    layout = json.loads(Path("examples/mockup1.layout.json").read_text())
+    resp = client.post("/factory/generate", json=layout)
+    assert resp.status_code == 200
+    swift = resp.json()["swift"]
+    assert "struct GeneratedView" in swift
+    assert 'Button("Get Started")' in swift

--- a/tests/integration/test_interpret_route_integration.py
+++ b/tests/integration/test_interpret_route_integration.py
@@ -1,0 +1,38 @@
+import json
+import sys
+import types
+from pathlib import Path
+
+from fastapi.testclient import TestClient
+from app.main import app
+
+
+def test_interpret_endpoint(monkeypatch):
+    if "openai" not in sys.modules:
+        sys.modules["openai"] = types.SimpleNamespace(api_key=None, ChatCompletion=types.SimpleNamespace())
+    import openai
+
+    layout_data = {
+        "structured": {
+            "type": "VStack",
+            "children": [
+                {"type": "Text", "text": "Welcome"},
+                {"type": "Button", "text": "Get Started"},
+            ],
+        },
+        "version": "layout-v1",
+    }
+
+    async def fake_acreate(*args, **kwargs):
+        return {"choices": [{"message": {"content": json.dumps(layout_data)}}]}
+
+    monkeypatch.setattr(openai.ChatCompletion, "acreate", fake_acreate, raising=False)
+
+    client = TestClient(app)
+    with Path("examples/mockup1.jpeg").open("rb") as f:
+        resp = client.post("/factory/interpret", files={"file": ("mockup1.jpeg", f, "image/jpeg")})
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["structured"]["type"] == "VStack"
+    assert any(c.get("type") == "Text" for c in data["structured"].get("children", []))

--- a/tests/unit/test_codegen_unit.py
+++ b/tests/unit/test_codegen_unit.py
@@ -1,0 +1,23 @@
+from app.models.layout import LayoutNode
+from app.services.codegen import generate_swift
+
+
+def test_generate_basic_vstack():
+    layout = LayoutNode(type="VStack", children=[LayoutNode(type="Text", text="Hello")])
+    swift = generate_swift(layout)
+    assert "struct GeneratedView" in swift
+    assert 'Text("Hello")' in swift
+
+
+def test_generate_conditional():
+    layout = LayoutNode(
+        type="Conditional",
+        condition="flag",
+        then=LayoutNode(type="Text", text="Yes"),
+        **{"else": LayoutNode(type="Text", text="No")}
+    )
+    swift = generate_swift(layout)
+    assert "if flag {" in swift
+    assert 'Text("Yes")' in swift
+    assert "} else {" in swift
+    assert 'Text("No")' in swift

--- a/tests/unit/test_layout_unit.py
+++ b/tests/unit/test_layout_unit.py
@@ -1,0 +1,24 @@
+import json
+from app.models.layout import LayoutNode
+
+
+def test_parse_layout_json():
+    with open("examples/mockup1.layout.json") as f:
+        data = json.load(f)
+    layout = LayoutNode(**data)
+    assert layout.type == "VStack"
+    assert len(layout.children or []) == 3
+    assert layout.children[0].type == "Text"
+
+
+def test_else_alias_handling():
+    data = {
+        "type": "Conditional",
+        "condition": "flag",
+        "then": {"type": "Text", "text": "Yes"},
+        "else": {"type": "Text", "text": "No"},
+    }
+    layout = LayoutNode(**data)
+    assert getattr(layout, "else_").type == "Text"
+    out = layout.dict()
+    assert out.get("else", {}).get("text") == "No"


### PR DESCRIPTION
## Summary
- add recursive dict conversion to `BaseModel` stub for nested model support
- add unit tests for layout parsing and SwiftUI code generation
- add integration tests covering `/interpret` and `/generate` endpoints
- add e2e test for mockup1 flow including build step

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6863feec47d0832599c85a70ee50618b