### PR TITLE
Add Xcode build strategy

### DIFF
--- a/docs/test_strategy.md
+++ b/docs/test_strategy.md
@@ -1,0 +1,42 @@
+# Xcode Test Strategy
+
+This repository includes Swift packages that build macOS and iOS user interfaces with AppKit or UIKit. To verify they compile correctly, we rely on **xcodebuild**. The build is scripted so that automation tools can inspect compiler results.
+
+## Goals
+
+1. Validate Swift packages compile without errors.
+2. Surface compiler diagnostics in CI or local scripts.
+3. Keep the process fully local without external dependencies beyond Xcode.
+
+## Running Tests
+
+Use `xcodebuild` directly to build the `DragAndDropApp` package. An example invocation:
+
+```bash
+xcodebuild \
+  -scheme DragAndDropApp \
+  -configuration Debug \
+  -destination 'platform=macOS' \
+  build 2>&1 | tee build.log
+```
+
+The command pipes all compiler output to `build.log`. The exit code of `xcodebuild` indicates success or failure. Review the log for warnings or errors.
+
+## Automating with a Script
+
+For convenience, create a small script (e.g. `scripts/build_app.sh`):
+
+```bash
+#!/bin/bash
+set -euo pipefail
+xcodebuild -scheme DragAndDropApp -configuration Debug -destination 'platform=macOS' build 2>&1 | tee build.log
+```
+
+Run the script locally or within your CI pipeline. The output file `build.log` will contain compiler diagnostics. Any build failure stops the script due to `set -e`.
+
+## Interpreting Results
+
+1. **Success** – `xcodebuild` exits with code `0`. Review `build.log` for warnings.
+2. **Failure** – a non-zero exit code indicates a compiler error. The offending lines appear in the log.
+
+This approach tests that your AppKit or UIKit code compiles on Apple platforms and provides a machine-readable log for further analysis.

--- a/scripts/build_app.sh
+++ b/scripts/build_app.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+set -euo pipefail
+xcodebuild -scheme DragAndDropApp -configuration Debug -destination 'platform=macOS' build 2>&1 | tee build.log


### PR DESCRIPTION
## Summary
- document how to build Swift packages with xcodebuild
- add a helper script to build DragAndDropApp using xcodebuild

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_686405a924888325bcdf60fdfe0bfab0