### PR TITLE
Expand component coverage

### DIFF
--- a/api/openapi.yml
+++ b/api/openapi.yml
@@ -173,6 +173,9 @@ components:
             - Conditional
             - TextField
             - Form
+            - List
+            - Section
+            - NavigationStack
         text:
           type: string
           nullable: true
@@ -183,7 +186,8 @@ components:
           nullable: true
           description: >
             Child layout nodes rendered inside container views. Multiple entries
-            are typically used for ``VStack``, ``HStack``, ``ZStack`` or ``Form`` groups.
+            are typically used for ``VStack``, ``HStack``, ``ZStack``, ``Form`` or
+            ``NavigationStack`` groups.
         condition:
           type: string
           description: Condition expression controlling the branch

--- a/app/models/layout.py
+++ b/app/models/layout.py
@@ -14,6 +14,9 @@ ComponentType = Literal[
     "Conditional",
     "TextField",
     "Form",
+    "List",
+    "Section",
+    "NavigationStack",
 ]
 
 
@@ -25,8 +28,9 @@ class LayoutNode(BaseModel):
     tag: Optional[str] = None
     type: ComponentType
     text: Optional[str] = None
-    # Container types like ``VStack``, ``ZStack`` or ``Form`` may hold multiple child
-    # nodes.  Non-container elements generally omit this field.
+    # Container types like ``VStack``, ``ZStack``, ``Form`` or ``NavigationStack``
+    # may hold multiple child nodes.  Non-container elements generally omit this
+    # field.
     children: Optional[List["LayoutNode"]] = None
     # Conditional layout support
     condition: Optional[str] = None

--- a/app/services/codegen.py
+++ b/app/services/codegen.py
@@ -88,6 +88,23 @@ def generate_swift(layout: LayoutNode) -> str:
             for child in node.children or []:
                 out.extend(render(child, depth + 1))
             out.append(f"{space}}}")
+        elif t == "NavigationStack":
+            out.append(f"{space}NavigationStack {{")
+            for child in node.children or []:
+                out.extend(render(child, depth + 1))
+            out.append(f"{space}}}")
+        elif t == "List":
+            out.append(f"{space}List {{")
+            for child in node.children or []:
+                out.extend(render(child, depth + 1))
+            out.append(f"{space}}}")
+        elif t == "Section":
+            header = f'header: Text("{escape(node.text)}")' if node.text else ""
+            prefix = f"Section({header})" if header else "Section"
+            out.append(f"{space}{prefix} {{")
+            for child in node.children or []:
+                out.extend(render(child, depth + 1))
+            out.append(f"{space}}}")
         elif t == "Form":
             out.append(f"{space}Form {{")
             for child in node.children or []:

--- a/tests/integration/test_generate_route_integration.py
+++ b/tests/integration/test_generate_route_integration.py
@@ -13,3 +13,29 @@ def test_generate_endpoint():
     swift = resp.json()["swift"]
     assert "struct GeneratedView" in swift
     assert 'Button("Get Started")' in swift
+
+
+def test_generate_endpoint_new_components():
+    client = TestClient(app)
+    layout = {
+        "type": "NavigationStack",
+        "children": [
+            {
+                "type": "List",
+                "children": [
+                    {
+                        "type": "Section",
+                        "text": "Header",
+                        "children": [{"type": "Text", "text": "Row1"}],
+                    }
+                ],
+            }
+        ],
+    }
+
+    resp = client.post("/factory/generate", json=layout)
+    assert resp.status_code == 200
+    swift = resp.json()["swift"]
+    assert "NavigationStack {" in swift
+    assert "List {" in swift
+    assert 'Section(header: Text("Header"))' in swift

--- a/tests/unit/test_codegen_unit.py
+++ b/tests/unit/test_codegen_unit.py
@@ -21,3 +21,27 @@ def test_generate_conditional():
     assert 'Text("Yes")' in swift
     assert "} else {" in swift
     assert 'Text("No")' in swift
+
+
+def test_generate_navigation_list_section():
+    layout = LayoutNode(
+        type="NavigationStack",
+        children=[
+            LayoutNode(
+                type="List",
+                children=[
+                    LayoutNode(
+                        type="Section",
+                        text="Header",
+                        children=[LayoutNode(type="Text", text="Row1")],
+                    )
+                ],
+            )
+        ],
+    )
+
+    swift = generate_swift(layout)
+    assert "NavigationStack {" in swift
+    assert "List {" in swift
+    assert 'Section(header: Text("Header"))' in swift
+    assert 'Text("Row1")' in swift


### PR DESCRIPTION
## Summary
- add List, Section, and NavigationStack types to layout model and OpenAPI spec
- extend Swift code generation to support the new components
- unit test code generation for new components
- integration test `/factory/generate` with new component layout

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_68641f578544832589571bd0d9ececbe