### PR TITLE
Add styling options to code generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,26 @@ uvicorn app.main:app --reload
 ```
 Visit http://localhost:8000/docs for interactive API docs.
 
+### Styling options
+The `/factory/generate` endpoint accepts a `style` object to customize
+generated SwiftUI code. Example payload:
+
+```json
+{
+  "layout": {"type": "VStack", "children": [{"type": "Text", "text": "Hello"}]},
+  "style": {
+    "indent": 4,
+    "header_comment": false,
+    "font": "title",
+    "color": "red",
+    "spacing": 8
+  }
+}
+```
+
+`font` and `color` apply to `Text` and `Button` views while `spacing` controls
+stack spacing. All fields are optional.
+
 ### Running tests
 ```bash
 pytest

--- a/api/openapi.yml
+++ b/api/openapi.yml
@@ -65,6 +65,15 @@ paths:
                     header_comment:
                       type: boolean
                       default: true
+                    font:
+                      type: string
+                      description: Font applied to Text and Button views
+                    color:
+                      type: string
+                      description: Foreground color name
+                    spacing:
+                      type: integer
+                      description: Spacing value for stacks
                 backend_hooks:
                   type: boolean
                   default: false

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -1,0 +1,4 @@
+from .layout import LayoutNode, LayoutInterpretationResponse
+from .style import StyleOptions
+
+__all__ = ["LayoutNode", "LayoutInterpretationResponse", "StyleOptions"]

--- a/app/models/style.py
+++ b/app/models/style.py
@@ -1,0 +1,12 @@
+from pydantic import BaseModel
+from typing import Optional
+
+
+class StyleOptions(BaseModel):
+    """Styling preferences for code generation."""
+
+    indent: int = 2
+    header_comment: bool = True
+    font: Optional[str] = None
+    color: Optional[str] = None
+    spacing: Optional[int] = None

--- a/app/routes/generate.py
+++ b/app/routes/generate.py
@@ -1,10 +1,28 @@
 from fastapi import APIRouter
+from pydantic import BaseModel
+from typing import Optional
 from app.services.codegen import generate_swift
 from app.models.layout import LayoutNode
+from app.models.style import StyleOptions
 
 router = APIRouter()
 
 
+class GenerateRequest(BaseModel):
+    layout: LayoutNode
+    name: Optional[str] = None
+    style: StyleOptions = StyleOptions()
+    backend_hooks: bool = False
+
+
 @router.post("/generate")
-async def generate(layout: LayoutNode):
-    return {"swift": generate_swift(layout)}
+async def generate(req: GenerateRequest):
+    layout = req.layout
+    if isinstance(layout, dict):
+        layout = LayoutNode(**layout)
+
+    style = req.style
+    if isinstance(style, dict):
+        style = StyleOptions(**style)
+
+    return {"swift": generate_swift(layout, style=style.__dict__)}

--- a/cli/vi.py
+++ b/cli/vi.py
@@ -55,6 +55,7 @@ def generate(obj: dict, layout_json: str) -> None:
     server: str = obj.get("server", BASE_URL)
     try:
         data = json.loads(Path(layout_json).read_text())
+        payload = {"layout": data}
     except FileNotFoundError:
         click.echo(f"File not found: {layout_json}", err=True)
         raise SystemExit(1)
@@ -63,7 +64,7 @@ def generate(obj: dict, layout_json: str) -> None:
         raise SystemExit(1)
 
     try:
-        resp = requests.post(f"{server}/factory/generate", json=data, timeout=30)
+        resp = requests.post(f"{server}/factory/generate", json=payload, timeout=30)
         resp.raise_for_status()
         swift = resp.json().get("swift", "")
         Path("GeneratedView.swift").write_text(swift)

--- a/tests/e2e/test_mockup1_flow_e2e.py
+++ b/tests/e2e/test_mockup1_flow_e2e.py
@@ -11,13 +11,25 @@ from app.main import app
 def test_mockup1_full_flow(monkeypatch):
     # prepare openai patch
     if "openai" not in sys.modules:
-        sys.modules["openai"] = types.SimpleNamespace(api_key=None, ChatCompletion=types.SimpleNamespace())
+        sys.modules["openai"] = types.SimpleNamespace(
+            api_key=None, ChatCompletion=types.SimpleNamespace()
+        )
     import openai
 
     layout_json = json.loads(Path("examples/mockup1.layout.json").read_text())
 
     async def fake_acreate(*args, **kwargs):
-        return {"choices": [{"message": {"content": json.dumps({"structured": layout_json, "version": "layout-v1"})}}]}
+        return {
+            "choices": [
+                {
+                    "message": {
+                        "content": json.dumps(
+                            {"structured": layout_json, "version": "layout-v1"}
+                        )
+                    }
+                }
+            ]
+        }
 
     monkeypatch.setattr(openai.ChatCompletion, "acreate", fake_acreate, raising=False)
 
@@ -26,20 +38,23 @@ def test_mockup1_full_flow(monkeypatch):
             returncode = 0
             stdout = "ok"
             stderr = ""
+
         return Result()
 
     monkeypatch.setattr(subprocess, "run", fake_run)
 
     client = TestClient(app)
     with Path("examples/mockup1.jpeg").open("rb") as f:
-        resp = client.post("/factory/interpret", files={"file": ("mockup1.jpeg", f, "image/jpeg")})
+        resp = client.post(
+            "/factory/interpret", files={"file": ("mockup1.jpeg", f, "image/jpeg")}
+        )
     assert resp.status_code == 200
     layout = resp.json()["structured"]
 
-    resp = client.post("/factory/generate", json=layout)
+    resp = client.post("/factory/generate", json={"layout": layout})
     swift = resp.json()["swift"]
 
-    for snippet in ["Text(\"Welcome\")", "Image(\"logo\")", "Button(\"Get Started\")"]:
+    for snippet in ['Text("Welcome")', 'Image("logo")', 'Button("Get Started")']:
         assert snippet in swift
 
     resp = client.post("/factory/test-build", json={"swift": swift})

--- a/tests/integration/test_generate_route_integration.py
+++ b/tests/integration/test_generate_route_integration.py
@@ -8,7 +8,7 @@ from app.main import app
 def test_generate_endpoint():
     client = TestClient(app)
     layout = json.loads(Path("examples/mockup1.layout.json").read_text())
-    resp = client.post("/factory/generate", json=layout)
+    resp = client.post("/factory/generate", json={"layout": layout})
     assert resp.status_code == 200
     swift = resp.json()["swift"]
     assert "struct GeneratedView" in swift
@@ -33,9 +33,26 @@ def test_generate_endpoint_new_components():
         ],
     }
 
-    resp = client.post("/factory/generate", json=layout)
+    resp = client.post("/factory/generate", json={"layout": layout})
     assert resp.status_code == 200
     swift = resp.json()["swift"]
     assert "NavigationStack {" in swift
     assert "List {" in swift
     assert 'Section(header: Text("Header"))' in swift
+
+
+def test_generate_endpoint_with_style():
+    client = TestClient(app)
+    layout = {"type": "VStack", "children": [{"type": "Text", "text": "Hello"}]}
+    resp = client.post(
+        "/factory/generate",
+        json={
+            "layout": layout,
+            "style": {"font": "title", "color": "red", "spacing": 5},
+        },
+    )
+    assert resp.status_code == 200
+    swift = resp.json()["swift"]
+    assert "VStack(spacing: 5)" in swift
+    assert ".font(.title)" in swift
+    assert ".foregroundColor(.red)" in swift

--- a/tests/integration/test_interpret_route_integration.py
+++ b/tests/integration/test_interpret_route_integration.py
@@ -9,7 +9,9 @@ from app.main import app
 
 def test_interpret_endpoint(monkeypatch):
     if "openai" not in sys.modules:
-        sys.modules["openai"] = types.SimpleNamespace(api_key=None, ChatCompletion=types.SimpleNamespace())
+        sys.modules["openai"] = types.SimpleNamespace(
+            api_key=None, ChatCompletion=types.SimpleNamespace()
+        )
     import openai
 
     layout_data = {
@@ -30,7 +32,9 @@ def test_interpret_endpoint(monkeypatch):
 
     client = TestClient(app)
     with Path("examples/mockup1.jpeg").open("rb") as f:
-        resp = client.post("/factory/interpret", files={"file": ("mockup1.jpeg", f, "image/jpeg")})
+        resp = client.post(
+            "/factory/interpret", files={"file": ("mockup1.jpeg", f, "image/jpeg")}
+        )
 
     assert resp.status_code == 200
     data = resp.json()

--- a/tests/unit/test_codegen_unit.py
+++ b/tests/unit/test_codegen_unit.py
@@ -45,3 +45,15 @@ def test_generate_navigation_list_section():
     assert "List {" in swift
     assert 'Section(header: Text("Header"))' in swift
     assert 'Text("Row1")' in swift
+
+
+def test_generate_with_style_options():
+    layout = LayoutNode(
+        type="VStack",
+        children=[LayoutNode(type="Text", text="Hello")],
+    )
+    style = {"font": "title", "color": "red", "spacing": 10}
+    swift = generate_swift(layout, style)
+    assert "VStack(spacing: 10)" in swift
+    assert ".font(.title)" in swift
+    assert ".foregroundColor(.red)" in swift


### PR DESCRIPTION
## Summary
- extend API style schema with `font`, `color`, and `spacing`
- implement `StyleOptions` model and apply styles in `generate_swift`
- update generate route and CLI to use new payload shape
- document styling options in README
- add tests for styling options

## Testing
- `black app tests cli --line-length 88`
- `PYTHONPATH=$PWD pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686421f04db08325b48a9448081efe29