### PR TITLE
Fix CLI package import for tests

### DIFF
--- a/cli/__init__.py
+++ b/cli/__init__.py
@@ -1,1 +1,0 @@
-"""CLI package"""


### PR DESCRIPTION
## Summary
- ensure `cli` is a package recognized by Python

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_686437ccc8ec8325974f994695497021