### PR TITLE
Fix tests by including requests dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ pydantic
 pytest
 click
 fastapi
+requests


### PR DESCRIPTION
## Summary
- include the `requests` module in `requirements.txt`

## Testing
- `pip install -r requirements.txt`
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68643c450ff88325bf7f4317e969a0b8