### PR TITLE
Fix Swift build warnings

### DIFF
--- a/DragAndDropApp/Sources/API.swift
+++ b/DragAndDropApp/Sources/API.swift
@@ -3,7 +3,7 @@ import Foundation
 import AppKit
 
 final class API {
-    static let shared = API()
+    @MainActor static let shared = API()
 
     let baseURL: URL
     private let session: URLSession

--- a/DragAndDropApp/Sources/AppConfig.swift
+++ b/DragAndDropApp/Sources/AppConfig.swift
@@ -2,7 +2,7 @@
 import Foundation
 
 final class AppConfig {
-    static let shared = AppConfig()
+    @MainActor static let shared = AppConfig()
 
     /// Base URL for the backend API.
     let baseURL: URL

--- a/DragAndDropApp/Sources/Models.swift
+++ b/DragAndDropApp/Sources/Models.swift
@@ -1,7 +1,7 @@
 /// Codable models corresponding to the View Factory API.
 import Foundation
 
-struct LayoutNode: Codable {
+final class LayoutNode: Codable {
     var id: String?
     var role: String?
     var tag: String?


### PR DESCRIPTION
## Summary
- make global singletons main-actor isolated
- convert `LayoutNode` to a class to allow recursion

## Testing
- `swift build` *(fails: no such module 'AppKit')*
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68643eb6fff0832581dd1f90de894232