### PR TITLE
Add SDK build support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,6 +50,8 @@ ruff_cache/
 !examples/*.swift
 !DragAndDropApp/**/*.swift
 !DragAndDropApp/**/*.json
+!SDK/**/Package.swift
+!SDK/**/*.swift
 !draganddrop-starter/*.layout.json
 
 # Ignore generated UI files if any

--- a/DragAndDropApp/Package.swift
+++ b/DragAndDropApp/Package.swift
@@ -11,9 +11,13 @@ let package = Package(
     products: [
         .executable(name: "DragAndDropApp", targets: ["DragAndDropApp"])
     ],
+    dependencies: [
+        .package(path: "../SDK/ExampleSDK")
+    ],
     targets: [
         .executableTarget(
             name: "DragAndDropApp",
+            dependencies: ["ExampleSDK"],
             path: "Sources"
         )
     ]

--- a/DragAndDropApp/Sources/ContentView.swift
+++ b/DragAndDropApp/Sources/ContentView.swift
@@ -1,11 +1,17 @@
 /// Main application view hosting the drag/drop area and code preview.
 import SwiftUI
 import AppKit
+#if canImport(ExampleSDK)
+import ExampleSDK
+#endif
 
 struct ContentView: View {
     @State private var selectedImage: NSImage? = nil
     @State private var generatedCode: String = ""
     @State private var isLoading: Bool = false
+#if canImport(ExampleSDK)
+    private let sdk = ExampleClient()
+#endif
 
     var body: some View {
         HStack {
@@ -28,6 +34,9 @@ struct ContentView: View {
         do {
             let layoutResponse = try await API.shared.interpret(image: image)
             generatedCode = try await API.shared.generate(from: layoutResponse.structured)
+#if canImport(ExampleSDK)
+            sdk.logMessage()
+#endif
         } catch {
             generatedCode = "Error: \(error.localizedDescription)"
         }

--- a/README.md
+++ b/README.md
@@ -104,6 +104,13 @@ The generated SwiftUI view will contain an `onAppear` modifier with a placeholde
 pytest
 ```
 
+### Client SDKs
+SwiftUI View Factory looks for Swift packages under the `SDK` directory. Any
+package found there is built before the demo applications when running
+`scripts/build_app.sh`. Use conditional imports (`#if canImport(...)`) within the
+apps to access your SDK at runtime. Compiler diagnostics from these builds are
+appended to `build.log` for review.
+
 ## Docker Support
 Build the container image:
 

--- a/SDK/ExampleSDK/Package.swift
+++ b/SDK/ExampleSDK/Package.swift
@@ -1,0 +1,17 @@
+// swift-tools-version: 6.1
+import PackageDescription
+
+let package = Package(
+    name: "ExampleSDK",
+    platforms: [
+        .macOS(.v13),
+        .iOS(.v17),
+        .visionOS(.v1)
+    ],
+    products: [
+        .library(name: "ExampleSDK", targets: ["ExampleSDK"])
+    ],
+    targets: [
+        .target(name: "ExampleSDK", path: "Sources")
+    ]
+)

--- a/SDK/ExampleSDK/Sources/ExampleSDK/ExampleClient.swift
+++ b/SDK/ExampleSDK/Sources/ExampleSDK/ExampleClient.swift
@@ -1,0 +1,6 @@
+public class ExampleClient {
+    public init() {}
+    public func logMessage() {
+        print("ExampleSDK loaded")
+    }
+}

--- a/SDK/README.md
+++ b/SDK/README.md
@@ -1,0 +1,8 @@
+# Client SDKs
+
+Place custom Swift packages in this directory. Each package should contain a
+`Package.swift` manifest so it can be built with Swift Package Manager.
+
+The build script (`scripts/build_app.sh`) automatically discovers SDK packages
+and compiles them before building the demo applications. Compiler diagnostics are
+captured in `build.log` for inspection.

--- a/VisionDemoApp/Package.swift
+++ b/VisionDemoApp/Package.swift
@@ -9,9 +9,13 @@ let package = Package(
     products: [
         .executable(name: "VisionDemoApp", targets: ["VisionDemoApp"])
     ],
+    dependencies: [
+        .package(path: "../SDK/ExampleSDK")
+    ],
     targets: [
         .executableTarget(
             name: "VisionDemoApp",
+            dependencies: ["ExampleSDK"],
             path: "Sources"
         )
     ]

--- a/VisionDemoApp/Sources/VisionDemoApp.swift
+++ b/VisionDemoApp/Sources/VisionDemoApp.swift
@@ -1,7 +1,18 @@
 import SwiftUI
+#if canImport(ExampleSDK)
+import ExampleSDK
+#endif
 
 @main
 struct VisionDemoApp: App {
+#if canImport(ExampleSDK)
+    private let sdk = ExampleClient()
+#endif
+    init() {
+#if canImport(ExampleSDK)
+        sdk.logMessage()
+#endif
+    }
     var body: some Scene {
         WindowGroup {
             GeneratedView()

--- a/iOSDemoApp/Package.swift
+++ b/iOSDemoApp/Package.swift
@@ -9,9 +9,13 @@ let package = Package(
     products: [
         .executable(name: "iOSDemoApp", targets: ["iOSDemoApp"])
     ],
+    dependencies: [
+        .package(path: "../SDK/ExampleSDK")
+    ],
     targets: [
         .executableTarget(
             name: "iOSDemoApp",
+            dependencies: ["ExampleSDK"],
             path: "Sources"
         )
     ]

--- a/iOSDemoApp/Sources/iOSDemoApp.swift
+++ b/iOSDemoApp/Sources/iOSDemoApp.swift
@@ -1,7 +1,18 @@
 import SwiftUI
+#if canImport(ExampleSDK)
+import ExampleSDK
+#endif
 
 @main
 struct iOSDemoApp: App {
+#if canImport(ExampleSDK)
+    private let sdk = ExampleClient()
+#endif
+    init() {
+#if canImport(ExampleSDK)
+        sdk.logMessage()
+#endif
+    }
     var body: some Scene {
         WindowGroup {
             GeneratedView()

--- a/scripts/build_app.sh
+++ b/scripts/build_app.sh
@@ -1,9 +1,27 @@
 #!/bin/bash
 set -euo pipefail
-xcodebuild -scheme DragAndDropApp -configuration Debug -destination 'platform=macOS' build 2>&1 | tee build.log
 
-if ! git diff --quiet build.log; then
-  git add build.log
+LOG="build.log"
+rm -f "$LOG"
+
+# Build any SDK packages first
+if [ -d "SDK" ]; then
+  for dir in SDK/*; do
+    [ -f "$dir/Package.swift" ] || continue
+    name=$(basename "$dir")
+    echo "Building $name" | tee -a "$LOG"
+    (cd "$dir" && xcodebuild -scheme "$name" -configuration Debug build 2>&1 | tee -a ../"$LOG")
+  done
+fi
+
+# Build demo applications
+xcodebuild -scheme DragAndDropApp -configuration Debug -destination 'platform=macOS' build 2>&1 | tee -a "$LOG"
+xcodebuild -scheme iOSDemoApp -configuration Debug -destination 'platform=iOS Simulator,name=iPhone 15' build 2>&1 | tee -a "$LOG"
+xcodebuild -scheme VisionDemoApp -configuration Debug -destination 'platform=visionOS Simulator,name=Apple Vision Pro' build 2>&1 | tee -a "$LOG"
+
+# Commit updated build log if it changed
+if [ -n "$(git status --porcelain $LOG)" ]; then
+  git add "$LOG"
   git commit -m "chore: update build log from latest Xcode build"
   git push origin main
 fi


### PR DESCRIPTION
## Summary
- add ExampleSDK placeholder with `ExampleClient`
- integrate ExampleSDK into demo apps with conditional imports
- build SDKs in scripts/build_app.sh before demo apps
- document SDK workflow in README and test strategy
- adjust .gitignore for SDK packages

## Testing
- `pip install -r requirements.txt`
- `pip install httpx`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6864c7cba2d08325bdde362865beee90