### PR TITLE
Expand styling options

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,13 +78,20 @@ generated SwiftUI code. Example payload:
     "header_comment": false,
     "font": "title",
     "color": "red",
-    "spacing": 8
+    "spacing": 8,
+    "bold": true,
+    "italic": true,
+    "padding": 4,
+    "background_color": "blue",
+    "corner_radius": 6
   }
 }
 ```
 
 `font` and `color` apply to `Text` and `Button` views while `spacing` controls
-stack spacing. All fields are optional.
+stack spacing. Additional options like `bold`, `italic`, `padding`,
+`background_color`, and `corner_radius` modify leaf views. All fields are
+optional.
 
 ### Backend hooks
 Enable `backend_hooks` to insert an `.onAppear` block for analytics or network

--- a/api/openapi.yml
+++ b/api/openapi.yml
@@ -92,6 +92,21 @@ paths:
                     spacing:
                       type: integer
                       description: Spacing value for stacks
+                    bold:
+                      type: boolean
+                      description: Apply bold styling to Text and Button views
+                    italic:
+                      type: boolean
+                      description: Apply italic styling to Text and Button views
+                    padding:
+                      type: integer
+                      description: Padding value applied to leaf views
+                    background_color:
+                      type: string
+                      description: Background color name
+                    corner_radius:
+                      type: integer
+                      description: Corner radius for leaf views
                 backend_hooks:
                   type: boolean
                   default: false

--- a/app/models/style.py
+++ b/app/models/style.py
@@ -10,3 +10,8 @@ class StyleOptions(BaseModel):
     font: Optional[str] = None
     color: Optional[str] = None
     spacing: Optional[int] = None
+    bold: bool = False
+    italic: bool = False
+    padding: Optional[int] = None
+    background_color: Optional[str] = None
+    corner_radius: Optional[int] = None

--- a/app/services/codegen.py
+++ b/app/services/codegen.py
@@ -36,6 +36,11 @@ def generate_swift(
         "font": None,
         "color": None,
         "spacing": None,
+        "bold": False,
+        "italic": False,
+        "padding": None,
+        "background_color": None,
+        "corner_radius": None,
         **(style or {}),
     }
 
@@ -44,6 +49,11 @@ def generate_swift(
     font_style = style.get("font")
     color_style = style.get("color")
     spacing = style.get("spacing")
+    bold = bool(style.get("bold", False))
+    italic = bool(style.get("italic", False))
+    padding = style.get("padding")
+    background_color = style.get("background_color")
+    corner_radius = style.get("corner_radius")
 
     lines: List[str] = []
 
@@ -74,6 +84,19 @@ def generate_swift(
 
     def escape(text: str) -> str:
         return text.replace('"', '\\"')
+
+    def add_modifiers(line: str) -> str:
+        if bold:
+            line += ".bold()"
+        if italic:
+            line += ".italic()"
+        if padding is not None:
+            line += f".padding({padding})"
+        if background_color:
+            line += f".background(Color.{background_color})"
+        if corner_radius:
+            line += f".cornerRadius({corner_radius})"
+        return line
 
     def render(node: LayoutNode, depth: int) -> List[str]:
         space = indent_unit * depth
@@ -133,12 +156,12 @@ def generate_swift(
                 line += ".foregroundColor(.gray)"
             elif color_style:
                 line += f".foregroundColor(.{color_style})"
-            out.append(line)
+            out.append(add_modifiers(line))
         elif t == "Image":
             name = escape(node.text or "")
-            out.append(f'{space}Image("{name}")')
+            out.append(add_modifiers(f'{space}Image("{name}")'))
         elif t == "Spacer":
-            out.append(f"{space}Spacer()")
+            out.append(add_modifiers(f"{space}Spacer()"))
         elif t == "Button":
             label = escape(node.text or "Button")
             line = f'{space}Button("{label}") {{}}'
@@ -148,11 +171,11 @@ def generate_swift(
                 line += f".font(.{font_style})"
             if color_style:
                 line += f".foregroundColor(.{color_style})"
-            out.append(line)
+            out.append(add_modifiers(line))
         elif t == "TextField":
             placeholder = escape(node.text or "")
             binding = node.id or "textField"
-            out.append(f'{space}TextField("{placeholder}", text: ${binding})')
+            out.append(add_modifiers(f'{space}TextField("{placeholder}", text: ${binding})'))
         elif t == "Conditional":
             cond = node.condition or "false"
             out.append(f"{space}if {cond} {{")

--- a/tests/integration/test_generate_route_integration.py
+++ b/tests/integration/test_generate_route_integration.py
@@ -58,6 +58,31 @@ def test_generate_endpoint_with_style():
     assert ".foregroundColor(.red)" in swift
 
 
+def test_generate_endpoint_extra_style():
+    client = TestClient(app)
+    layout = {"type": "Text", "text": "Styled"}
+    resp = client.post(
+        "/factory/generate",
+        json={
+            "layout": layout,
+            "style": {
+                "bold": True,
+                "italic": True,
+                "padding": 8,
+                "background_color": "green",
+                "corner_radius": 4,
+            },
+        },
+    )
+    assert resp.status_code == 200
+    swift = resp.json()["swift"]
+    assert ".bold()" in swift
+    assert ".italic()" in swift
+    assert ".padding(8)" in swift
+    assert ".background(Color.green)" in swift
+    assert ".cornerRadius(4)" in swift
+
+
 def test_generate_endpoint_backend_hooks():
     client = TestClient(app)
     layout = {"type": "Text", "text": "Hi"}

--- a/tests/unit/test_codegen_unit.py
+++ b/tests/unit/test_codegen_unit.py
@@ -115,3 +115,20 @@ def test_generate_with_indent_and_header_off():
     lines = swift.splitlines()
     assert lines[0].startswith("struct GeneratedView")
     assert lines[1].startswith("    var body")
+
+
+def test_generate_with_extra_style_modifiers():
+    layout = LayoutNode(type="Text", text="Styled")
+    style = {
+        "bold": True,
+        "italic": True,
+        "padding": 4,
+        "background_color": "blue",
+        "corner_radius": 5,
+    }
+    swift = generate_swift(layout, style)
+    assert ".bold()" in swift
+    assert ".italic()" in swift
+    assert ".padding(4)" in swift
+    assert ".background(Color.blue)" in swift
+    assert ".cornerRadius(5)" in swift


### PR DESCRIPTION
## Summary
- expand API & README to mention new styling options (bold, italic, padding, background, corner radius)
- extend `StyleOptions` and `generate_swift` to use these options
- add tests for extra style modifiers

## Testing
- `pip install httpx`
- `export PYTHONPATH=. && pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6864ca44e79c832599bd6b0fa6723da0