### PR TITLE
Fix macOS build by specifying deployment target

### DIFF
--- a/ExampleApp/Package.swift
+++ b/ExampleApp/Package.swift
@@ -4,7 +4,8 @@ import PackageDescription
 let package = Package(
     name: "ExampleApp",
     platforms: [
-        .iOS(.v17)
+        .iOS(.v17),
+        .macOS(.v13)
     ],
     products: [
         .executable(name: "ExampleApp", targets: ["ExampleApp"])


### PR DESCRIPTION
## Summary
- set macOS 13 as the minimum platform for ExampleApp

## Testing
- `pip install -r requirements.txt`
- `pip install httpx`
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6864d283ab308325b9ca4c66f91ae005