### PR TITLE
Add build verification to CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,10 @@ python cli/vi.py interpret Images/demo_mockup.jpeg
 python cli/vi.py generate Layouts/demo_app.layout.json
 python cli/vi.py test GeneratedView.swift
 ```
+Add `--verify-build` when generating to ensure the Swift code compiles:
+```bash
+python cli/vi.py generate Layouts/demo_app.layout.json --verify-build
+```
 
 ### Local FastAPI launch
 ```bash

--- a/USAGE.md
+++ b/USAGE.md
@@ -19,6 +19,12 @@ python cli/vi.py generate Layouts/demo_app.layout.json \
   --indent 4 --no-header --backend-hooks
 ```
 
+Add `--verify-build` to compile the generated code before saving:
+
+```bash
+python cli/vi.py generate Layouts/demo_app.layout.json --verify-build
+```
+
 ## FastAPI
 Launch the API locally with Uvicorn:
 


### PR DESCRIPTION
## Summary
- add `--verify-build` option to `vi generate`
- document verifying build in README and USAGE
- test CLI build verification flag

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_6864ed4ffda883258676e2bc588d6c4b