### PR TITLE
Fix CI workflow reliability

### DIFF
--- a/.github/workflows/process-images.yml
+++ b/.github/workflows/process-images.yml
@@ -33,6 +33,18 @@ jobs:
           nohup uvicorn app.main:app --host 0.0.0.0 --port 8000 &
           sleep 5
 
+      - name: Wait for API to be ready
+        run: |
+          for i in {1..10}; do
+            if curl --fail http://localhost:8000/docs > /dev/null 2>&1; then
+              echo "API is up"
+              exit 0
+            fi
+            sleep 2
+          done
+          echo "API failed to start" >&2
+          exit 1
+
       - name: Process new images
         env:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}


### PR DESCRIPTION
## Summary
- add API readiness check in process-images workflow to avoid 500 errors

## Testing
- `PYTHONPATH=$PWD pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68651f950be08325947859a8f8268722