### PR TITLE
Add manual image workflow trigger

### DIFF
--- a/.github/workflows/process-images.yml
+++ b/.github/workflows/process-images.yml
@@ -4,6 +4,7 @@ on:
   push:
     paths:
       - 'Images/**'
+  workflow_dispatch:
 
 jobs:
   generate:
@@ -49,5 +50,9 @@ jobs:
         env:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
         run: |
-          ./scripts/process_images.sh
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            ./scripts/process_images.sh --latest
+          else
+            ./scripts/process_images.sh
+          fi
 

--- a/scripts/process_images.sh
+++ b/scripts/process_images.sh
@@ -4,7 +4,20 @@ set -euo pipefail
 # Generate layout JSON and Swift views for images in the Images directory.
 # Requires the API server to be running and OPENAI_API_KEY if using OpenAI.
 
-for img in Images/*.{png,jpg,jpeg,JPG,JPEG,PNG}; do
+if [ "${1:-}" = "--latest" ]; then
+  img=$(ls -1t Images/*.{png,jpg,jpeg,JPG,JPEG,PNG} 2>/dev/null | head -n 1 || true)
+  if [ -z "$img" ]; then
+    echo "No images found" >&2
+    exit 0
+  fi
+  images=("$img")
+elif [ "$#" -gt 0 ]; then
+  images=("$@")
+else
+  images=(Images/*.{png,jpg,jpeg,JPG,JPEG,PNG})
+fi
+
+for img in "${images[@]}"; do
   [ -e "$img" ] || continue
   base=$(basename "$img")
   name="${base%.*}"


### PR DESCRIPTION
## Summary
- allow manual invocation of the image processing workflow
- process only the latest image on manual run

## Testing
- `pip install -r requirements.txt`
- `pip install httpx`
- `PYTHONPATH=$PWD pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6865218adc5083258932909325944aec