### PR TITLE
Fix default API base URL

### DIFF
--- a/api/openapi.yml
+++ b/api/openapi.yml
@@ -25,7 +25,9 @@ info:
   version: 1.2.0
 
 servers:
-  - url: http://localhost:8000/api/v1
+  # The FastAPI server is mounted at the root path when run locally, so the
+  # specification should reflect the unversioned base URL.
+  - url: http://localhost:8000
 
 paths:
   /factory/interpret:

--- a/cli/vi.py
+++ b/cli/vi.py
@@ -8,7 +8,9 @@ from typing import Optional
 import click
 import requests
 
-BASE_URL = "http://localhost:8000/api/v1"
+# Default API base URL. The FastAPI application does not include a versioned
+# prefix, so requests should target the root server address by default.
+BASE_URL = "http://localhost:8000"
 
 
 @click.group()


### PR DESCRIPTION
## Summary
- make CLI default to http://localhost:8000
- update OpenAPI spec example server

## Testing
- `PYTHONPATH=$PWD pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6865268b03088325a896511272e0ba02