### PR TITLE
Fix CLI layout validation

### DIFF
--- a/cli/vi.py
+++ b/cli/vi.py
@@ -80,6 +80,22 @@ def generate(
     server: str = obj.get("server", BASE_URL)
     try:
         data = json.loads(Path(layout_json).read_text())
+
+        # When the layout file comes directly from the ``interpret`` command
+        # it contains a ``structured`` key with the actual layout tree.  The
+        # interpreter may also return an error object with a ``code`` field.
+        if isinstance(data, dict):
+            if "code" in data and "structured" not in data:
+                msg = data.get("message", "Invalid layout file")
+                click.echo(f"Invalid layout: {msg}", err=True)
+                raise SystemExit(1)
+            if "structured" in data:
+                data = data["structured"]
+
+        if not isinstance(data, dict) or "type" not in data:
+            click.echo("Invalid layout: missing 'type'", err=True)
+            raise SystemExit(1)
+
         payload = {"layout": data}
         if name:
             payload["name"] = name

--- a/tests/unit/test_cli_generate.py
+++ b/tests/unit/test_cli_generate.py
@@ -77,3 +77,18 @@ def test_generate_verify_build(monkeypatch):
         assert result.exit_code == 0
         assert calls[0].endswith('/factory/generate')
         assert calls[1].endswith('/factory/test-build')
+
+
+def test_generate_invalid_layout(monkeypatch):
+    """Generating should fail when the JSON lacks a layout tree."""
+    runner = CliRunner()
+
+    with runner.isolated_filesystem():
+        layout_path = 'layout.json'
+        with open(layout_path, 'w') as f:
+            json.dump({'code': 'openai_error', 'message': 'failure'}, f)
+
+        result = runner.invoke(cli, ['generate', layout_path])
+
+        assert result.exit_code != 0
+        assert 'Invalid layout' in result.output


### PR DESCRIPTION
## Summary
- handle `interpret` error output in `generate` command
- test CLI behavior when layout JSON is invalid

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68653043d0ac8325bcf26f0371a2db61