### PR TITLE
Fix API key handling and improve workflow

### DIFF
--- a/.github/workflows/process-images.yml
+++ b/.github/workflows/process-images.yml
@@ -9,6 +9,8 @@ on:
 jobs:
   generate:
     runs-on: ubuntu-latest
+    env:
+      OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
     steps:
       - uses: actions/checkout@v3
 
@@ -28,27 +30,23 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
       - name: Start API server
-        env:
-          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
         run: |
           nohup uvicorn app.main:app --host 0.0.0.0 --port 8000 &
           sleep 5
 
       - name: Wait for API to be ready
         run: |
-          for i in {1..10}; do
+          for i in {1..20}; do
             if curl --fail http://localhost:8000/docs > /dev/null 2>&1; then
               echo "API is up"
               exit 0
             fi
-            sleep 2
+            sleep 3
           done
           echo "API failed to start" >&2
           exit 1
 
       - name: Process new images
-        env:
-          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
         run: |
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
             ./scripts/process_images.sh --latest

--- a/app/services/interpreter.py
+++ b/app/services/interpreter.py
@@ -33,6 +33,9 @@ async def interpret_image(file: UploadFile) -> LayoutInterpretationResponse | Er
     )
 
     try:
+        if not openai.api_key:
+            raise RuntimeError("OPENAI_API_KEY is not set")
+
         # Read and base64 encode the uploaded image for GPT-4 vision models
         content = await file.read()
         encoded = base64.b64encode(content).decode("utf-8")

--- a/tests/e2e/test_mockup1_flow_e2e.py
+++ b/tests/e2e/test_mockup1_flow_e2e.py
@@ -15,6 +15,7 @@ def test_mockup1_full_flow(monkeypatch):
             api_key=None, ChatCompletion=types.SimpleNamespace()
         )
     import openai
+    openai.api_key = "test"
 
     layout_data = json.loads(Path("Layouts/example_app.layout.json").read_text())
 

--- a/tests/integration/test_interpret_route_integration.py
+++ b/tests/integration/test_interpret_route_integration.py
@@ -13,6 +13,7 @@ def test_interpret_endpoint(monkeypatch):
             api_key=None, ChatCompletion=types.SimpleNamespace()
         )
     import openai
+    openai.api_key = "test"
 
     layout_data = {
         "structured": {


### PR DESCRIPTION
## Summary
- require OPENAI_API_KEY when calling the interpreter service
- set the OpenAI key at the job level in process-images workflow and wait longer for server startup
- update tests to supply a dummy API key for patched OpenAI calls

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686534f04b7c832595bea06be239b4bb