### PR TITLE
Improve OpenAI error transparency

### DIFF
--- a/Layouts/3-try.layout.json
+++ b/Layouts/3-try.layout.json
@@ -1,5 +1,5 @@
 {
   "code": "openai_error",
-  "message": "OpenAI API error",
+  "message": "OpenAI API error: OPENAI_API_KEY is not set",
   "detail": ""
 }

--- a/app/services/interpreter.py
+++ b/app/services/interpreter.py
@@ -5,6 +5,7 @@ import openai
 import base64
 import json
 import os
+import traceback
 from dotenv import load_dotenv
 
 load_dotenv()
@@ -73,8 +74,8 @@ async def interpret_image(file: UploadFile) -> LayoutInterpretationResponse | Er
     except Exception as exc:
         return ErrorResponse(
             code="openai_error",
-            message="OpenAI API error",
-            detail=str(exc),
+            message=f"OpenAI API error: {exc}",
+            detail=traceback.format_exc(),
         )
 
     try:

--- a/tests/integration/test_interpret_route_integration.py
+++ b/tests/integration/test_interpret_route_integration.py
@@ -41,3 +41,29 @@ def test_interpret_endpoint(monkeypatch):
     data = resp.json()
     assert data["structured"]["type"] == "VStack"
     assert any(c.get("type") == "Text" for c in data["structured"].get("children", []))
+
+
+def test_interpret_openai_error(monkeypatch):
+    if "openai" not in sys.modules:
+        sys.modules["openai"] = types.SimpleNamespace(
+            api_key=None, ChatCompletion=types.SimpleNamespace()
+        )
+    import openai
+    openai.api_key = "test"
+
+    async def fake_acreate(*args, **kwargs):
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(openai.ChatCompletion, "acreate", fake_acreate, raising=False)
+
+    client = TestClient(app)
+    with Path("Images/example_app_mockup.jpeg").open("rb") as f:
+        resp = client.post(
+            "/factory/interpret", files={"file": ("example_app_mockup.jpeg", f, "image/jpeg")}
+        )
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["code"] == "openai_error"
+    assert "boom" in data["message"]
+    assert "RuntimeError" in data["detail"]


### PR DESCRIPTION
## Summary
- improve error handling in interpreter service
- update example layout to show descriptive error message
- test OpenAI error handling via new integration test

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68653874d1348325b940859a75c3221a