### PR TITLE
Ensure OPENAI key sourced from secrets

### DIFF
--- a/.github/workflows/process-images.yml
+++ b/.github/workflows/process-images.yml
@@ -9,8 +9,6 @@ on:
 jobs:
   generate:
     runs-on: ubuntu-latest
-    env:
-      OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
     steps:
       - uses: actions/checkout@v3
 
@@ -18,6 +16,9 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: '3.11'
+
+      - name: Export OpenAI API key
+        run: echo "OPENAI_API_KEY=${{ secrets.OPENAI_API_KEY }}" >> $GITHUB_ENV
 
       - name: Install dependencies
         run: |


### PR DESCRIPTION
## Summary
- retrieve `OPENAI_API_KEY` from repo secrets before running the image workflow

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68653ab877a883258fafa4b9bdd6a4dd