### PR TITLE
Improve error reporting for layout generation

### DIFF
--- a/cli/vi.py
+++ b/cli/vi.py
@@ -88,6 +88,12 @@ def generate(
             if "code" in data and "structured" not in data:
                 msg = data.get("message", "Invalid layout file")
                 click.echo(f"Invalid layout: {msg}", err=True)
+                detail = data.get("detail")
+                if detail:
+                    click.echo(detail, err=True)
+                log_path = Path(layout_json).with_suffix(".error.log")
+                Path(log_path).write_text(json.dumps(data, indent=2))
+                click.echo(f"Wrote error details to {log_path}", err=True)
                 raise SystemExit(1)
             if "structured" in data:
                 data = data["structured"]

--- a/tests/unit/test_cli_generate.py
+++ b/tests/unit/test_cli_generate.py
@@ -92,3 +92,7 @@ def test_generate_invalid_layout(monkeypatch):
 
         assert result.exit_code != 0
         assert 'Invalid layout' in result.output
+        assert 'Wrote error details' in result.output
+        with open('layout.error.log') as f:
+            err = json.load(f)
+        assert err['code'] == 'openai_error'


### PR DESCRIPTION
## Summary
- log OpenAI errors to a `.error.log` file when generating Swift
- test new CLI error reporting

## Testing
- `pip install -q -r requirements.txt`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68654b2a5bf0832594e823f737a499fa