### PR TITLE
Improve error reporting for layout generation

### DIFF
--- a/api/openapi.yml
+++ b/api/openapi.yml
@@ -187,6 +187,9 @@ components:
         version:
           type: string
           example: "layout-v1"
+        log:
+          type: string
+          description: Raw communication log between the service and OpenAI
 
     LayoutNode:
       type: object
@@ -259,4 +262,8 @@ components:
           example: One or more fields are invalid.
         detail:
           type: string
-          nullable: true# Insert the finalized OpenAPI spec here
+          nullable: true
+        log:
+          type: string
+          nullable: true
+          description: Raw communication log if available

--- a/app/models/error.py
+++ b/app/models/error.py
@@ -5,3 +5,4 @@ class ErrorResponse(BaseModel):
     code: str
     message: str
     detail: Optional[str] = None
+    log: Optional[str] = None

--- a/app/models/layout.py
+++ b/app/models/layout.py
@@ -74,3 +74,4 @@ class LayoutInterpretationResponse(BaseModel):
     structured: LayoutNode
     description: Optional[str] = None
     version: str = "layout-v1"
+    log: Optional[str] = None

--- a/tests/integration/test_interpret_route_integration.py
+++ b/tests/integration/test_interpret_route_integration.py
@@ -41,6 +41,10 @@ def test_interpret_endpoint(monkeypatch):
     data = resp.json()
     assert data["structured"]["type"] == "VStack"
     assert any(c.get("type") == "Text" for c in data["structured"].get("children", []))
+    log_path = Path("Layouts/example_app_mockup.openai.log")
+    assert log_path.exists()
+    log = json.loads(log_path.read_text())
+    assert "request" in log
 
 
 def test_interpret_openai_error(monkeypatch):
@@ -67,3 +71,7 @@ def test_interpret_openai_error(monkeypatch):
     assert data["code"] == "openai_error"
     assert "boom" in data["message"]
     assert "RuntimeError" in data["detail"]
+    log_path = Path("Layouts/example_app_mockup.openai.log")
+    assert log_path.exists()
+    log = json.loads(log_path.read_text())
+    assert "error" in log

--- a/tests/unit/test_cli_generate.py
+++ b/tests/unit/test_cli_generate.py
@@ -86,9 +86,16 @@ def test_generate_invalid_layout(monkeypatch):
     with runner.isolated_filesystem():
         layout_path = 'layout.json'
         with open(layout_path, 'w') as f:
-            json.dump({'code': 'openai_error', 'message': 'failure'}, f)
+            json.dump({'code': 'openai_error', 'message': 'failure', 'log': 'foo'}, f)
 
         result = runner.invoke(cli, ['generate', layout_path])
 
         assert result.exit_code != 0
         assert 'Invalid layout' in result.output
+        assert 'Wrote error details' in result.output
+        assert 'Wrote OpenAI log' in result.output
+        with open('layout.error.log') as f:
+            err = json.load(f)
+        assert err['code'] == 'openai_error'
+        with open('layout.openai.log') as f:
+            assert 'foo' in f.read()


### PR DESCRIPTION
## Summary
- log OpenAI errors to a `.error.log` file when generating Swift
- test new CLI error reporting
- record raw conversation with OpenAI to a `.openai.log` file

## Testing
- `pip install -q -r requirements.txt`
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68654b2a5bf0832594e823f737a499fa