### PR TITLE
Fix log files not being committed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,8 @@ ruff_cache/
 
 # Logs and debug
 *.log
+!Layouts/*.openai.log
+!Layouts/*.error.log
 
 # Output
 *.swift


### PR DESCRIPTION
## Summary
- allow `Layouts/*.openai.log` and `Layouts/*.error.log` in gitignore

## Testing
- `PYTHONPATH=$PWD pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6865520a7e2c8325ace1a96ed30bb68d