### PR TITLE
Document OpenAI secret path in API spec

### DIFF
--- a/api/openapi.yml
+++ b/api/openapi.yml
@@ -172,6 +172,22 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
 
+  /secret:
+    get:
+      summary: Retrieve the OpenAI API key
+      description: |
+        Returns the API key used when communicating with OpenAI. In local
+        development the key is loaded from a `.env` file. In production the
+        container expects the `OPENAI_API_KEY` environment variable to be set.
+      operationId: getOpenAIKey
+      responses:
+        '200':
+          description: API key response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OpenAIKeyResponse'
+
 components:
   schemas:
     LayoutInterpretationResponse:
@@ -267,3 +283,9 @@ components:
           type: string
           nullable: true
           description: Raw communication log if available
+
+    OpenAIKeyResponse:
+      type: object
+      properties:
+        api_key:
+          type: string


### PR DESCRIPTION
## Summary
- extend main OpenAPI contract with the `/secret` endpoint
- describe the `OpenAIKeyResponse` schema used by this route

## Testing
- `pip install -q -r requirements.txt`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686568a828208325bab6a95056f634fe