### PR TITLE
Add Docker setup and CI pipelines

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -1,0 +1,22 @@
+name: Smoke Test
+on:
+  workflow_dispatch:
+
+jobs:
+  smoke:
+    runs-on: ubuntu-latest
+    env:
+      OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+    steps:
+      - uses: actions/checkout@v3
+      - name: Run smoke test
+        run: |
+          ./scripts/smoke_test.sh
+      - name: Upload logs
+        uses: actions/upload-artifact@v3
+        with:
+          name: smoke-logs
+          path: ci-logs
+      - name: Commit logs
+        run: |
+          ./scripts/store_logs.sh

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,23 @@
+name: CI
+on:
+  pull_request:
+  push:
+    branches: [ main ]
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    env:
+      OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Docker Compose
+        run: docker-compose -f docker-compose.yml up --build --exit-code-from test
+      - name: Upload logs
+        uses: actions/upload-artifact@v3
+        with:
+          name: test-logs
+          path: ci-logs
+      - name: Commit logs
+        run: |
+          ./scripts/store_logs.sh

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,6 @@
+# Repository Instructions
+
+- Use **Black** with default settings to format Python code.
+- Run `pytest` before committing any changes.
+- CI logs are stored in the `ci-logs/` directory. Do not delete existing log files.
+- Docker containers use Python 3.11. Use the provided Dockerfile and docker-compose for local testing.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM python:3.11-slim
+WORKDIR /app
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+COPY . .
+ENV PYTHONUNBUFFERED=1
+CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/app/main.py
+++ b/app/main.py
@@ -18,6 +18,7 @@ def custom_openapi():
         schema = yaml.safe_load(f)
     return schema
 
+
 app.openapi = custom_openapi
 
 
@@ -53,8 +54,14 @@ class OpenAIKeyResponse(BaseModel):
 @app.post("/factory/interpret", response_model=LayoutInterpretationResponse)
 async def interpret_layout(file: UploadFile = File(...)):
     # Placeholder logic that returns a static layout
-    root_node = LayoutNode(type="VStack", children=[LayoutNode(type="Text", text="Hello")])
-    return LayoutInterpretationResponse(structured=root_node, description="Simple VStack with Hello text", version="layout-v1")
+    root_node = LayoutNode(
+        type="VStack", children=[LayoutNode(type="Text", text="Hello")]
+    )
+    return LayoutInterpretationResponse(
+        structured=root_node,
+        description="Simple VStack with Hello text",
+        version="layout-v1",
+    )
 
 
 class GenerateRequest(BaseModel):
@@ -67,7 +74,7 @@ class GenerateRequest(BaseModel):
 @app.post("/factory/generate")
 async def generate_swiftui_view(data: GenerateRequest):
     name = data.name or "GeneratedView"
-    swift = f"struct {name}: View {{\n    var body: some View {{\n        Text(\"Hello\")\n    }}\n}}"
+    swift = f'struct {name}: View {{\n    var body: some View {{\n        Text("Hello")\n    }}\n}}'
     return {"swift": swift}
 
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,13 @@
+version: "3.8"
+services:
+  web:
+    build: .
+    environment:
+      - OPENAI_API_KEY=${OPENAI_API_KEY}
+    ports:
+      - "8000:8000"
+  test:
+    build: .
+    environment:
+      - OPENAI_API_KEY=${OPENAI_API_KEY}
+    command: pytest -vv

--- a/scripts/smoke_test.sh
+++ b/scripts/smoke_test.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+set -euo pipefail
+export OPENAI_API_KEY=${OPENAI_API_KEY:-test}
+# Start the app
+container_id=$(docker run -d -p 8000:8000 -e OPENAI_API_KEY="$OPENAI_API_KEY" $(docker build -q .))
+# Wait for the app to be up
+attempts=0
+until curl -sf http://localhost:8000/secret >/dev/null || [ $attempts -ge 10 ]; do
+  sleep 2
+  attempts=$((attempts+1))
+  echo "Waiting for app..."
+done
+# Call endpoints
+curl -s -H "Authorization: Bearer $OPENAI_API_KEY" http://localhost:8000/secret > ci-logs/smoke_secret.json
+curl -s -X POST http://localhost:8000/factory/generate -H 'Content-Type: application/json' -d '{"layout": {"type": "Text", "text": "Hi"}}' > ci-logs/smoke_generate.json
+# Stop container
+docker stop "$container_id"

--- a/scripts/store_logs.sh
+++ b/scripts/store_logs.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+set -euo pipefail
+LOG_DIR="ci-logs"
+mkdir -p "$LOG_DIR"
+LOG_FILE="$LOG_DIR/test.log"
+# Capture docker-compose logs
+if [ -f docker-compose.yml ]; then
+  docker-compose logs --no-color > "$LOG_FILE" || true
+fi
+# Configure git
+git config user.name "github-actions"
+git config user.email "github-actions@users.noreply.github.com"
+# Commit and push logs
+if [ -n "$(git status --porcelain $LOG_DIR)" ]; then
+  git add "$LOG_DIR"
+  git commit -m "Update CI logs" || true
+  git push origin HEAD
+fi

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -18,17 +18,16 @@ def test_interpret_layout(tmp_path):
     file_path = tmp_path / "mock.png"
     file_path.write_bytes(b"fake")
     with file_path.open("rb") as f:
-        response = client.post("/factory/interpret", files={"file": ("mock.png", f, "image/png")})
+        response = client.post(
+            "/factory/interpret", files={"file": ("mock.png", f, "image/png")}
+        )
     assert response.status_code == 200
     data = response.json()
     assert data["structured"]["type"] == "VStack"
 
 
 def test_generate_swiftui_view():
-    payload = {
-        "layout": {"type": "Text", "text": "Hello"},
-        "name": "MyView"
-    }
+    payload = {"layout": {"type": "Text", "text": "Hello"}, "name": "MyView"}
     response = client.post("/factory/generate", json=payload)
     assert response.status_code == 200
     assert "struct MyView" in response.json()["swift"]


### PR DESCRIPTION
## Summary
- add instructions for agents
- dockerize the FastAPI app
- run tests and smoke tests via GitHub Actions
- upload and commit CI logs for traceability

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6865734baeac8325b92c0a9c6a9e1e9f