### PR TITLE
Fix CI workflow to install Docker Compose

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,6 +11,10 @@ jobs:
       OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
     steps:
       - uses: actions/checkout@v3
+      - name: Install Docker Compose
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y docker-compose
       - name: Set up Docker Compose
         run: docker-compose -f docker-compose.yml up --build --exit-code-from test
       - name: Upload logs


### PR DESCRIPTION
## Summary
- install Docker Compose during CI before starting `docker-compose`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6865755a35f48325bb6b31fda2001c9d