### PR TITLE
Fix module import in build workflow

### DIFF
--- a/.github/workflows/build_views.yml
+++ b/.github/workflows/build_views.yml
@@ -22,6 +22,8 @@ jobs:
           python-version: '3.11'
       - name: Install dependencies
         run: pip install -r requirements.txt
+      - name: Set PYTHONPATH
+        run: echo "PYTHONPATH=$PYTHONPATH:$(pwd)" >> $GITHUB_ENV
       - name: Build SwiftUI views
         run: |
           python scripts/build_views.py --upload "${{ github.event.inputs.upload_dir }}" --download "${{ github.event.inputs.download_dir }}"


### PR DESCRIPTION
## Summary
- ensure Python can find the `app` package when building views

## Testing
- `black .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68657b4ad9848325810c2ce88a616c9d