### PR TITLE
Use API for build views workflow

### DIFF
--- a/.github/workflows/build_views.yml
+++ b/.github/workflows/build_views.yml
@@ -24,9 +24,45 @@ jobs:
         run: pip install -r requirements.txt
       - name: Set PYTHONPATH
         run: echo "PYTHONPATH=$PYTHONPATH:$(pwd)" >> $GITHUB_ENV
-      - name: Build SwiftUI views
+      - name: Start API server
         run: |
-          python scripts/build_views.py --upload "${{ github.event.inputs.upload_dir }}" --download "${{ github.event.inputs.download_dir }}"
+          uvicorn app.main:app --host 0.0.0.0 --port 8000 &
+          echo $! > uvicorn.pid
+          for i in {1..10}; do
+            if curl -sf http://localhost:8000/secret > /dev/null; then
+              break
+            fi
+            sleep 2
+          done
+      - name: Generate SwiftUI views via API
+        run: |
+          python - <<'EOF'
+          import os, json, glob, os.path, httpx
+
+          upload = os.environ["UPLOAD_DIR"]
+          download = os.environ["DOWNLOAD_DIR"]
+          os.makedirs(download, exist_ok=True)
+
+          for path in glob.glob(os.path.join(upload, "*.json")):
+              with open(path) as f:
+                  layout = json.load(f)
+              name = os.path.splitext(os.path.basename(path))[0]
+              resp = httpx.post(
+                  "http://localhost:8000/factory/generate",
+                  json={"layout": layout, "name": name},
+              )
+              resp.raise_for_status()
+              swift = resp.json()["swift"]
+              with open(os.path.join(download, f"{name}.swift"), "w") as out:
+                  out.write(swift)
+          EOF
+        env:
+          UPLOAD_DIR: ${{ github.event.inputs.upload_dir }}
+          DOWNLOAD_DIR: ${{ github.event.inputs.download_dir }}
+      - name: Stop API server
+        if: always()
+        run: |
+          kill $(cat uvicorn.pid)
       - name: Upload generated views
         uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
## Summary
- update `build_views` workflow to start the server and call the `/factory/generate` API

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6865839a3d0883259378dc574df9e1aa