### PR TITLE
Fix secret usage in build workflow

### DIFF
--- a/.github/workflows/build_views.yml
+++ b/.github/workflows/build_views.yml
@@ -14,6 +14,8 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    env:
+      OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python


### PR DESCRIPTION
## Summary
- ensure `OPENAI_API_KEY` from GitHub secrets is available in the `build_views` workflow

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686584f783ac832587481d3c8a87003f