### PR TITLE
Update upload-artifact action to v4

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -13,7 +13,7 @@ jobs:
         run: |
           ./scripts/smoke_test.sh
       - name: Upload logs
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: smoke-logs
           path: ci-logs


### PR DESCRIPTION
## Summary
- fix GitHub action using deprecated `actions/upload-artifact@v3`

## Testing
- `black . --check`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686587adcf18832592c06d266686ee91