### PR TITLE
Fix image_url format for OpenAI API

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -75,7 +75,7 @@ async def interpret_layout(file: UploadFile = File(...)):
                     },
                     {
                         "type": "image_url",
-                        "image_url": f"data:{file.content_type};base64,{b64}",
+                        "image_url": {"url": f"data:{file.content_type};base64,{b64}"},
                     },
                 ],
             },


### PR DESCRIPTION
## Summary
- fix message format for `image_url` payload in the interpret endpoint

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686604a8fe908325bdb819da9de09f80