### PR TITLE
Enable OpenAI logging and docker log hook

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,8 +6,12 @@ services:
       - OPENAI_API_KEY=${OPENAI_API_KEY}
     ports:
       - "8000:8000"
+    volumes:
+      - ./ci-logs:/app/ci-logs
   test:
     build: .
     environment:
       - OPENAI_API_KEY=${OPENAI_API_KEY}
+    volumes:
+      - ./ci-logs:/app/ci-logs
     command: pytest -vv

--- a/scripts/install_hooks.sh
+++ b/scripts/install_hooks.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+set -euo pipefail
+HOOK_DIR=".git/hooks"
+mkdir -p "$HOOK_DIR"
+HOOK_PATH="$HOOK_DIR/post-commit"
+cat <<'EOL' > "$HOOK_PATH"
+#!/bin/bash
+scripts/store_logs.sh >/dev/null 2>&1
+EOL
+chmod +x "$HOOK_PATH"
+echo "Post-commit hook installed to capture docker logs."
+


### PR DESCRIPTION
## Summary
- log all OpenAI API responses to `ci-logs/openai.log`
- mount the repository `ci-logs` directory into Docker containers
- provide an `install_hooks.sh` script that installs a `post-commit` hook for storing container logs

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68663475b0508325887acada27a1379a