### PR TITLE
Add critique and updated OpenAPI spec

### DIFF
--- a/api-versioning/openapi_critique.md
+++ b/api-versioning/openapi_critique.md
@@ -1,0 +1,38 @@
+# Critique of `api/openapi.yml`
+
+The current API specification focuses on generic actions for interpreting UI
+mockups and generating SwiftUI code. However, it does not explicitly state that
+the interpretation step relies on OpenAI's GPT-4o vision capabilities. The
+`/secret` endpoint merely exposes the API key through an additional route,
+burdening clients with retrieving a constant secret that should normally be
+injected via environment variables.
+
+## Issues
+
+1. **Lack of explicit contract with GPT-4o**
+   - `/factory/interpret` only mentions uploading a mockup. It does not make it
+     clear that the backend sends the image to GPT-4o for vision analysis.
+   - Consumers cannot easily know which model or version is used, so they cannot
+     reason about costs or capabilities.
+
+2. **Unnecessary `/secret` endpoint**
+   - Fetching the OpenAI API key over HTTP is insecure and complicates the API.
+   - The key is constant for a deployment and should be injected via
+     configuration rather than fetched at runtime.
+
+3. **Versioning**
+   - The spec version is `1.2.0`, but the change history is unclear.
+   - There is no place for experimenting with new versions.
+
+## Suggested Update
+
+- Make the dependency on GPT-4o explicit in the description and in the
+  `interpret` endpoint.
+- Add an optional `gpt_model` parameter allowing clients to specify the desired
+  OpenAI model (defaulting to `gpt-4o`).
+- Remove the `/secret` endpoint and rely on environment variables for API key
+  management.
+- Increment the spec version to `1.3.0` and store updated specs under the new
+  `api-versioning` directory for clarity.
+
+The file [`openapi_v1.3.yml`](openapi_v1.3.yml) reflects these changes.

--- a/api-versioning/openapi_v1.3.yml
+++ b/api-versioning/openapi_v1.3.yml
@@ -1,0 +1,225 @@
+openapi: 3.1.0
+info:
+  title: SwiftUI View Factory API
+  description: |
+    This version explicitly describes the service's reliance on the
+    OpenAI GPT-4o model for vision interpretation.
+
+    The API converts UI mockups or structured layout trees
+    into production-grade SwiftUI views. Only a curated subset of SwiftUI
+    components is supported.
+  version: 1.3.0
+
+servers:
+  - url: http://localhost:8000
+    description: Local development server
+  - url: https://api.fountain.coach/v1
+    description: Production v1
+
+security:
+  - BearerAuth: []
+
+tags:
+  - name: Factory
+    description: Convert mockups and layout trees into SwiftUI views
+
+paths:
+  /factory/interpret:
+    post:
+      summary: Interpret UI mockup image with GPT-4o
+      description: |
+        Upload a UI mock or sketch. The service sends the image to the
+        OpenAI GPT-4o model and returns a structured layout tree.
+      operationId: interpretLayoutV13
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              properties:
+                file:
+                  type: string
+                  format: binary
+                gpt_model:
+                  type: string
+                  default: gpt-4o
+                  description: OpenAI model name used for interpretation
+      responses:
+        '200':
+          description: Structured layout response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/LayoutInterpretationResponse'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  /factory/generate:
+    post:
+      summary: Generate SwiftUI view code
+      description: |
+        Converts a structured layout into a SwiftUI `View` struct with
+        optional backend wiring.
+      operationId: generateSwiftUIView
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                layout:
+                  $ref: '#/components/schemas/LayoutNode'
+                name:
+                  type: string
+                  description: Optional name for the generated SwiftUI view
+                style:
+                  type: object
+                  properties:
+                    indent:
+                      type: integer
+                      default: 2
+                    header_comment:
+                      type: boolean
+                      default: true
+                    font:
+                      type: string
+                      description: Font applied to Text and Button views
+                    color:
+                      type: string
+                      description: Foreground color name
+                    spacing:
+                      type: integer
+                      description: Spacing value for stacks
+                    bold:
+                      type: boolean
+                      description: Apply bold styling to Text and Button views
+                    italic:
+                      type: boolean
+                      description: Apply italic styling to Text and Button views
+                    padding:
+                      type: integer
+                      description: Padding value applied to leaf views
+                    background_color:
+                      type: string
+                      description: Background color name
+                    corner_radius:
+                      type: integer
+                      description: Corner radius for leaf views
+                backend_hooks:
+                  type: boolean
+                  default: false
+                  description: |
+                    If true, the generated SwiftUI view includes an `.onAppear`
+                    block where analytics or network logic can be invoked.
+      responses:
+        '200':
+          description: Generated SwiftUI view code
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  swift:
+                    type: string
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+components:
+  securitySchemes:
+    BearerAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: JWT
+  schemas:
+    LayoutInterpretationResponse:
+      type: object
+      required:
+        - structured
+      properties:
+        structured:
+          $ref: '#/components/schemas/LayoutNode'
+        description:
+          type: string
+          description: Optional natural language summary
+        version:
+          type: string
+          example: "layout-v1"
+        log:
+          type: string
+          description: Raw communication log between the service and OpenAI
+    LayoutNode:
+      type: object
+      required:
+        - type
+      properties:
+        id:
+          type: string
+          description: A unique node identifier
+        role:
+          type: string
+          nullable: true
+        tag:
+          type: string
+          nullable: true
+        type:
+          type: string
+          description: SwiftUI component type
+          enum:
+            - VStack
+            - HStack
+            - Text
+            - Image
+            - Button
+            - Spacer
+            - ScrollView
+            - ZStack
+            - Conditional
+            - TextField
+            - Form
+            - List
+            - Section
+            - NavigationStack
+        text:
+          type: string
+          nullable: true
+        children:
+          type: array
+          items:
+            $ref: '#/components/schemas/LayoutNode'
+          nullable: true
+          description: >-
+            Child layout nodes rendered inside container views.
+        condition:
+          type: string
+          nullable: true
+        then:
+          $ref: '#/components/schemas/LayoutNode'
+          nullable: true
+        else:
+          $ref: '#/components/schemas/LayoutNode'
+          nullable: true
+    ErrorResponse:
+      type: object
+      required:
+        - code
+        - message
+      properties:
+        code:
+          type: string
+        message:
+          type: string
+        detail:
+          type: string
+          nullable: true
+        log:
+          type: string
+          nullable: true


### PR DESCRIPTION
## Summary
- document shortcomings of the existing API
- provide an updated spec that explicitly references GPT‑4o vision and removes the /secret endpoint

## Testing
- `bash scripts/dispatch.sh --selftest`

------
https://chatgpt.com/codex/tasks/task_e_6867fd8e16288325b345e0d8cba5a2c2