### PR TITLE
Implement OpenAPI client handlers

### DIFF
--- a/docs/openapi-handler-implementation.md
+++ b/docs/openapi-handler-implementation.md
@@ -12,12 +12,12 @@ plain HTTP requests.
 ```yaml
 deploy: handlers/deploy.sh
 backup: handlers/backup.py
-interpret: handlers/interpret.py
-generate: handlers/generate.py
-secret: handlers/secret.py
+interpretLayout: handlers/interpretLayout.py
+generateSwiftUIView: handlers/generateSwiftUIView.py
+getOpenAIKey: handlers/getOpenAIKey.py
 ```
 
-## `handlers/interpret.py`
+## `handlers/interpretLayout.py`
 
 Uploads a mockup image to `/factory/interpret` and stores the JSON
 response in the log directory.
@@ -27,7 +27,10 @@ response in the log directory.
 import os
 import sys
 import yaml
-import requests
+import json
+from client.swift_ui_view_factory_api_client import Client
+from client.swift_ui_view_factory_api_client.models import InterpretLayoutBody, File
+from client.swift_ui_view_factory_api_client.api.factory import interpret_layout
 
 request_file = sys.argv[1]
 log_dir = sys.argv[2]
@@ -35,35 +38,24 @@ log_dir = sys.argv[2]
 with open(request_file) as f:
     data = yaml.safe_load(f)
 
-spec = data.get('spec', {})
-file_path = spec.get('file')
+file_path = data.get('spec', {}).get('file')
 
-base_url = os.getenv('API_BASE_URL', 'http://localhost:8000')
-url = f"{base_url}/factory/interpret"
+client = Client(base_url=os.getenv('API_BASE_URL', 'http://localhost:8000'))
 
-response_file = os.path.join(log_dir, 'interpret_response.json')
+response_file = os.path.join(log_dir, 'interpretLayout_response.json')
 status_file = os.path.join(log_dir, 'status.yml')
 
-try:
-    with open(file_path, 'rb') as fp:
-        files = {'file': fp}
-        resp = requests.post(url, files=files)
-    with open(response_file, 'w') as f:
-        f.write(resp.text)
-    if resp.ok:
-        with open(status_file, 'w') as f:
-            f.write('status: success\n')
-    else:
-        with open(status_file, 'w') as f:
-            f.write('status: failure\n')
-except Exception as e:
-    with open(os.path.join(log_dir, 'error.log'), 'w') as f:
-        f.write(str(e))
-    with open(status_file, 'w') as f:
-        f.write('status: error\n')
+with open(file_path, 'rb') as fp:
+    body = InterpretLayoutBody(file=File(payload=fp, file_name=os.path.basename(file_path)))
+    resp = interpret_layout.sync(client=client, body=body)
+
+with open(response_file, 'w') as f:
+    json.dump(resp.to_dict(), f, indent=2)
+with open(status_file, 'w') as f:
+    f.write('status: success\n')
 ```
 
-## `handlers/generate.py`
+## `handlers/generateSwiftUIView.py`
 
 Posts a layout tree to `/factory/generate` and writes the resulting
 Swift code JSON to the logs.
@@ -83,30 +75,21 @@ with open(request_file) as f:
 
 spec = data.get('spec', {})
 
-base_url = os.getenv('API_BASE_URL', 'http://localhost:8000')
-url = f"{base_url}/factory/generate"
+client = Client(base_url=os.getenv('API_BASE_URL', 'http://localhost:8000'))
 
-response_file = os.path.join(log_dir, 'generate_response.json')
+response_file = os.path.join(log_dir, 'generateSwiftUIView_response.json')
 status_file = os.path.join(log_dir, 'status.yml')
 
-try:
-    resp = requests.post(url, json=spec)
-    with open(response_file, 'w') as f:
-        f.write(resp.text)
-    if resp.ok:
-        with open(status_file, 'w') as f:
-            f.write('status: success\n')
-    else:
-        with open(status_file, 'w') as f:
-            f.write('status: failure\n')
-except Exception as e:
-    with open(os.path.join(log_dir, 'error.log'), 'w') as f:
-        f.write(str(e))
-    with open(status_file, 'w') as f:
-        f.write('status: error\n')
+body = GenerateSwiftUIViewBody.from_dict(spec)
+resp = generate_swift_ui_view.sync(client=client, body=body)
+
+with open(response_file, 'w') as f:
+    json.dump(resp.to_dict(), f, indent=2)
+with open(status_file, 'w') as f:
+    f.write('status: success\n')
 ```
 
-## `handlers/secret.py`
+## `handlers/getOpenAIKey.py`
 
 Calls `/secret` to retrieve the API key. The response body is saved in
 the log directory.
@@ -115,32 +98,24 @@ the log directory.
 #!/usr/bin/env python3
 import os
 import sys
-import requests
+import json
+from client.swift_ui_view_factory_api_client import Client
+from client.swift_ui_view_factory_api_client.api.secrets import get_open_ai_key
 
 request_file = sys.argv[1]
 log_dir = sys.argv[2]
 
-base_url = os.getenv('API_BASE_URL', 'http://localhost:8000')
-url = f"{base_url}/secret"
+client = Client(base_url=os.getenv('API_BASE_URL', 'http://localhost:8000'))
 
-response_file = os.path.join(log_dir, 'secret_response.json')
+response_file = os.path.join(log_dir, 'getOpenAIKey_response.json')
 status_file = os.path.join(log_dir, 'status.yml')
 
-try:
-    resp = requests.get(url)
-    with open(response_file, 'w') as f:
-        f.write(resp.text)
-    if resp.ok:
-        with open(status_file, 'w') as f:
-            f.write('status: success\n')
-    else:
-        with open(status_file, 'w') as f:
-            f.write('status: failure\n')
-except Exception as e:
-    with open(os.path.join(log_dir, 'error.log'), 'w') as f:
-        f.write(str(e))
-    with open(status_file, 'w') as f:
-        f.write('status: error\n')
+resp = get_open_ai_key.sync(client=client)
+
+with open(response_file, 'w') as f:
+    json.dump(resp.to_dict(), f, indent=2)
+with open(status_file, 'w') as f:
+    f.write('status: success\n')
 ```
 
 All handlers rely on the `API_BASE_URL` environment variable. If it is

--- a/docs/openapi-handler-proposal.md
+++ b/docs/openapi-handler-proposal.md
@@ -25,8 +25,8 @@ applies to any OpenAPI specification.
      URL from an environment variable.
 
 2. **Define request kinds**
-   - Add new kinds such as `interpret` and `generate` to `handlers/index.yml`.
-   - Each kind maps to a handler script (e.g., `handlers/interpret.py`).
+   - Add new kinds using the `operationId` from the OpenAPI spec as the handler name.
+   - For example, `interpretLayout` maps to `handlers/interpretLayout.py` and `generateSwiftUIView` maps to `handlers/generateSwiftUIView.py`.
 
 3. **Implement the handler scripts**
    - Parse the YAML file to extract parameters.
@@ -50,8 +50,8 @@ applies to any OpenAPI specification.
      name: HelloView
    ```
 
-   Dispatching this file triggers `handlers/generate.py` which calls the
-   `/factory/generate` endpoint and writes the resulting Swift code to the log.
+  Dispatching this file triggers `handlers/generateSwiftUIView.py` which calls the
+  `/factory/generate` endpoint and writes the resulting Swift code to the log.
 
 ## Generalizing to Other OpenAPIs
 

--- a/handlers/client/.gitignore
+++ b/handlers/client/.gitignore
@@ -1,0 +1,23 @@
+__pycache__/
+build/
+dist/
+*.egg-info/
+.pytest_cache/
+
+# pyenv
+.python-version
+
+# Environments
+.env
+.venv
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# JetBrains
+.idea/
+
+/coverage.xml
+/.coverage

--- a/handlers/client/README.md
+++ b/handlers/client/README.md
@@ -1,0 +1,124 @@
+# swift-ui-view-factory-api-client
+A client library for accessing SwiftUI View Factory API
+
+## Usage
+First, create a client:
+
+```python
+from swift_ui_view_factory_api_client import Client
+
+client = Client(base_url="https://api.example.com")
+```
+
+If the endpoints you're going to hit require authentication, use `AuthenticatedClient` instead:
+
+```python
+from swift_ui_view_factory_api_client import AuthenticatedClient
+
+client = AuthenticatedClient(base_url="https://api.example.com", token="SuperSecretToken")
+```
+
+Now call your endpoint and use your models:
+
+```python
+from swift_ui_view_factory_api_client.models import MyDataModel
+from swift_ui_view_factory_api_client.api.my_tag import get_my_data_model
+from swift_ui_view_factory_api_client.types import Response
+
+with client as client:
+    my_data: MyDataModel = get_my_data_model.sync(client=client)
+    # or if you need more info (e.g. status_code)
+    response: Response[MyDataModel] = get_my_data_model.sync_detailed(client=client)
+```
+
+Or do the same thing with an async version:
+
+```python
+from swift_ui_view_factory_api_client.models import MyDataModel
+from swift_ui_view_factory_api_client.api.my_tag import get_my_data_model
+from swift_ui_view_factory_api_client.types import Response
+
+async with client as client:
+    my_data: MyDataModel = await get_my_data_model.asyncio(client=client)
+    response: Response[MyDataModel] = await get_my_data_model.asyncio_detailed(client=client)
+```
+
+By default, when you're calling an HTTPS API it will attempt to verify that SSL is working correctly. Using certificate verification is highly recommended most of the time, but sometimes you may need to authenticate to a server (especially an internal server) using a custom certificate bundle.
+
+```python
+client = AuthenticatedClient(
+    base_url="https://internal_api.example.com", 
+    token="SuperSecretToken",
+    verify_ssl="/path/to/certificate_bundle.pem",
+)
+```
+
+You can also disable certificate validation altogether, but beware that **this is a security risk**.
+
+```python
+client = AuthenticatedClient(
+    base_url="https://internal_api.example.com", 
+    token="SuperSecretToken", 
+    verify_ssl=False
+)
+```
+
+Things to know:
+1. Every path/method combo becomes a Python module with four functions:
+    1. `sync`: Blocking request that returns parsed data (if successful) or `None`
+    1. `sync_detailed`: Blocking request that always returns a `Request`, optionally with `parsed` set if the request was successful.
+    1. `asyncio`: Like `sync` but async instead of blocking
+    1. `asyncio_detailed`: Like `sync_detailed` but async instead of blocking
+
+1. All path/query params, and bodies become method arguments.
+1. If your endpoint had any tags on it, the first tag will be used as a module name for the function (my_tag above)
+1. Any endpoint which did not have a tag will be in `swift_ui_view_factory_api_client.api.default`
+
+## Advanced customizations
+
+There are more settings on the generated `Client` class which let you control more runtime behavior, check out the docstring on that class for more info. You can also customize the underlying `httpx.Client` or `httpx.AsyncClient` (depending on your use-case):
+
+```python
+from swift_ui_view_factory_api_client import Client
+
+def log_request(request):
+    print(f"Request event hook: {request.method} {request.url} - Waiting for response")
+
+def log_response(response):
+    request = response.request
+    print(f"Response event hook: {request.method} {request.url} - Status {response.status_code}")
+
+client = Client(
+    base_url="https://api.example.com",
+    httpx_args={"event_hooks": {"request": [log_request], "response": [log_response]}},
+)
+
+# Or get the underlying httpx client to modify directly with client.get_httpx_client() or client.get_async_httpx_client()
+```
+
+You can even set the httpx client directly, but beware that this will override any existing settings (e.g., base_url):
+
+```python
+import httpx
+from swift_ui_view_factory_api_client import Client
+
+client = Client(
+    base_url="https://api.example.com",
+)
+# Note that base_url needs to be re-set, as would any shared cookies, headers, etc.
+client.set_httpx_client(httpx.Client(base_url="https://api.example.com", proxies="http://localhost:8030"))
+```
+
+## Building / publishing this package
+This project uses [Poetry](https://python-poetry.org/) to manage dependencies  and packaging.  Here are the basics:
+1. Update the metadata in pyproject.toml (e.g. authors, version)
+1. If you're using a private repository, configure it with Poetry
+    1. `poetry config repositories.<your-repository-name> <url-to-your-repository>`
+    1. `poetry config http-basic.<your-repository-name> <username> <password>`
+1. Publish the client with `poetry publish --build -r <your-repository-name>` or, if for public PyPI, just `poetry publish --build`
+
+If you want to install this client into another project without publishing it (e.g. for development) then:
+1. If that project **is using Poetry**, you can simply do `poetry add <path-to-this-client>` from that project
+1. If that project is not using Poetry:
+    1. Build a wheel with `poetry build -f wheel`
+    1. Install that wheel from the other project `pip install <path-to-wheel>`

--- a/handlers/client/pyproject.toml
+++ b/handlers/client/pyproject.toml
@@ -1,0 +1,27 @@
+[tool.poetry]
+name = "swift-ui-view-factory-api-client"
+version = "1.2.0"
+description = "A client library for accessing SwiftUI View Factory API"
+authors = []
+readme = "README.md"
+packages = [
+    {include = "swift_ui_view_factory_api_client"},
+]
+include = ["CHANGELOG.md", "swift_ui_view_factory_api_client/py.typed"]
+
+
+[tool.poetry.dependencies]
+python = "^3.9"
+httpx = ">=0.23.0,<0.29.0"
+attrs = ">=22.2.0"
+python-dateutil = "^2.8.0"
+
+[build-system]
+requires = ["poetry-core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"
+
+[tool.ruff]
+line-length = 120
+
+[tool.ruff.lint]
+select = ["F", "I", "UP"]

--- a/handlers/client/swift_ui_view_factory_api_client/__init__.py
+++ b/handlers/client/swift_ui_view_factory_api_client/__init__.py
@@ -1,0 +1,8 @@
+"""A client library for accessing SwiftUI View Factory API"""
+
+from .client import AuthenticatedClient, Client
+
+__all__ = (
+    "AuthenticatedClient",
+    "Client",
+)

--- a/handlers/client/swift_ui_view_factory_api_client/api/__init__.py
+++ b/handlers/client/swift_ui_view_factory_api_client/api/__init__.py
@@ -1,0 +1,1 @@
+"""Contains methods for accessing the API"""

--- a/handlers/client/swift_ui_view_factory_api_client/api/factory/__init__.py
+++ b/handlers/client/swift_ui_view_factory_api_client/api/factory/__init__.py
@@ -1,0 +1,1 @@
+"""Contains endpoint functions for accessing the API"""

--- a/handlers/client/swift_ui_view_factory_api_client/api/factory/generate_swift_ui_view.py
+++ b/handlers/client/swift_ui_view_factory_api_client/api/factory/generate_swift_ui_view.py
@@ -1,0 +1,172 @@
+from http import HTTPStatus
+from typing import Any, Optional, Union
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.error_response import ErrorResponse
+from ...models.generate_swift_ui_view_body import GenerateSwiftUIViewBody
+from ...models.generate_swift_ui_view_response_200 import GenerateSwiftUIViewResponse200
+from ...types import Response
+
+
+def _get_kwargs(
+    *,
+    body: GenerateSwiftUIViewBody,
+) -> dict[str, Any]:
+    headers: dict[str, Any] = {}
+
+    _kwargs: dict[str, Any] = {
+        "method": "post",
+        "url": "/factory/generate",
+    }
+
+    _kwargs["json"] = body.to_dict()
+
+    headers["Content-Type"] = "application/json"
+
+    _kwargs["headers"] = headers
+    return _kwargs
+
+
+def _parse_response(
+    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+) -> Optional[Union[ErrorResponse, GenerateSwiftUIViewResponse200]]:
+    if response.status_code == 200:
+        response_200 = GenerateSwiftUIViewResponse200.from_dict(response.json())
+
+        return response_200
+    if response.status_code == 422:
+        response_422 = ErrorResponse.from_dict(response.json())
+
+        return response_422
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+) -> Response[Union[ErrorResponse, GenerateSwiftUIViewResponse200]]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    *,
+    client: Union[AuthenticatedClient, Client],
+    body: GenerateSwiftUIViewBody,
+) -> Response[Union[ErrorResponse, GenerateSwiftUIViewResponse200]]:
+    """Generate SwiftUI view code
+
+     Converts a structured layout into a SwiftUI `View` struct with optional backend wiring.
+
+    Args:
+        body (GenerateSwiftUIViewBody):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Union[ErrorResponse, GenerateSwiftUIViewResponse200]]
+    """
+
+    kwargs = _get_kwargs(
+        body=body,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    *,
+    client: Union[AuthenticatedClient, Client],
+    body: GenerateSwiftUIViewBody,
+) -> Optional[Union[ErrorResponse, GenerateSwiftUIViewResponse200]]:
+    """Generate SwiftUI view code
+
+     Converts a structured layout into a SwiftUI `View` struct with optional backend wiring.
+
+    Args:
+        body (GenerateSwiftUIViewBody):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Union[ErrorResponse, GenerateSwiftUIViewResponse200]
+    """
+
+    return sync_detailed(
+        client=client,
+        body=body,
+    ).parsed
+
+
+async def asyncio_detailed(
+    *,
+    client: Union[AuthenticatedClient, Client],
+    body: GenerateSwiftUIViewBody,
+) -> Response[Union[ErrorResponse, GenerateSwiftUIViewResponse200]]:
+    """Generate SwiftUI view code
+
+     Converts a structured layout into a SwiftUI `View` struct with optional backend wiring.
+
+    Args:
+        body (GenerateSwiftUIViewBody):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Union[ErrorResponse, GenerateSwiftUIViewResponse200]]
+    """
+
+    kwargs = _get_kwargs(
+        body=body,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    *,
+    client: Union[AuthenticatedClient, Client],
+    body: GenerateSwiftUIViewBody,
+) -> Optional[Union[ErrorResponse, GenerateSwiftUIViewResponse200]]:
+    """Generate SwiftUI view code
+
+     Converts a structured layout into a SwiftUI `View` struct with optional backend wiring.
+
+    Args:
+        body (GenerateSwiftUIViewBody):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Union[ErrorResponse, GenerateSwiftUIViewResponse200]
+    """
+
+    return (
+        await asyncio_detailed(
+            client=client,
+            body=body,
+        )
+    ).parsed

--- a/handlers/client/swift_ui_view_factory_api_client/api/factory/interpret_layout.py
+++ b/handlers/client/swift_ui_view_factory_api_client/api/factory/interpret_layout.py
@@ -1,0 +1,170 @@
+from http import HTTPStatus
+from typing import Any, Optional, Union
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.error_response import ErrorResponse
+from ...models.interpret_layout_body import InterpretLayoutBody
+from ...models.layout_interpretation_response import LayoutInterpretationResponse
+from ...types import Response
+
+
+def _get_kwargs(
+    *,
+    body: InterpretLayoutBody,
+) -> dict[str, Any]:
+    headers: dict[str, Any] = {}
+
+    _kwargs: dict[str, Any] = {
+        "method": "post",
+        "url": "/factory/interpret",
+    }
+
+    _kwargs["files"] = body.to_multipart()
+
+    _kwargs["headers"] = headers
+    return _kwargs
+
+
+def _parse_response(
+    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+) -> Optional[Union[ErrorResponse, LayoutInterpretationResponse]]:
+    if response.status_code == 200:
+        response_200 = LayoutInterpretationResponse.from_dict(response.json())
+
+        return response_200
+    if response.status_code == 422:
+        response_422 = ErrorResponse.from_dict(response.json())
+
+        return response_422
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+) -> Response[Union[ErrorResponse, LayoutInterpretationResponse]]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    *,
+    client: Union[AuthenticatedClient, Client],
+    body: InterpretLayoutBody,
+) -> Response[Union[ErrorResponse, LayoutInterpretationResponse]]:
+    """Interpret UI mockup image
+
+     Upload a UI mock or sketch to generate a structured layout tree.
+
+    Args:
+        body (InterpretLayoutBody):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Union[ErrorResponse, LayoutInterpretationResponse]]
+    """
+
+    kwargs = _get_kwargs(
+        body=body,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    *,
+    client: Union[AuthenticatedClient, Client],
+    body: InterpretLayoutBody,
+) -> Optional[Union[ErrorResponse, LayoutInterpretationResponse]]:
+    """Interpret UI mockup image
+
+     Upload a UI mock or sketch to generate a structured layout tree.
+
+    Args:
+        body (InterpretLayoutBody):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Union[ErrorResponse, LayoutInterpretationResponse]
+    """
+
+    return sync_detailed(
+        client=client,
+        body=body,
+    ).parsed
+
+
+async def asyncio_detailed(
+    *,
+    client: Union[AuthenticatedClient, Client],
+    body: InterpretLayoutBody,
+) -> Response[Union[ErrorResponse, LayoutInterpretationResponse]]:
+    """Interpret UI mockup image
+
+     Upload a UI mock or sketch to generate a structured layout tree.
+
+    Args:
+        body (InterpretLayoutBody):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Union[ErrorResponse, LayoutInterpretationResponse]]
+    """
+
+    kwargs = _get_kwargs(
+        body=body,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    *,
+    client: Union[AuthenticatedClient, Client],
+    body: InterpretLayoutBody,
+) -> Optional[Union[ErrorResponse, LayoutInterpretationResponse]]:
+    """Interpret UI mockup image
+
+     Upload a UI mock or sketch to generate a structured layout tree.
+
+    Args:
+        body (InterpretLayoutBody):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Union[ErrorResponse, LayoutInterpretationResponse]
+    """
+
+    return (
+        await asyncio_detailed(
+            client=client,
+            body=body,
+        )
+    ).parsed

--- a/handlers/client/swift_ui_view_factory_api_client/api/secrets/__init__.py
+++ b/handlers/client/swift_ui_view_factory_api_client/api/secrets/__init__.py
@@ -1,0 +1,1 @@
+"""Contains endpoint functions for accessing the API"""

--- a/handlers/client/swift_ui_view_factory_api_client/api/secrets/get_open_ai_key.py
+++ b/handlers/client/swift_ui_view_factory_api_client/api/secrets/get_open_ai_key.py
@@ -1,0 +1,142 @@
+from http import HTTPStatus
+from typing import Any, Optional, Union
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.open_ai_key_response import OpenAIKeyResponse
+from ...types import Response
+
+
+def _get_kwargs() -> dict[str, Any]:
+    _kwargs: dict[str, Any] = {
+        "method": "get",
+        "url": "/secret",
+    }
+
+    return _kwargs
+
+
+def _parse_response(
+    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+) -> Optional[OpenAIKeyResponse]:
+    if response.status_code == 200:
+        response_200 = OpenAIKeyResponse.from_dict(response.json())
+
+        return response_200
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+) -> Response[OpenAIKeyResponse]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    *,
+    client: Union[AuthenticatedClient, Client],
+) -> Response[OpenAIKeyResponse]:
+    """Retrieve the OpenAI API key
+
+     Returns the API key used when communicating with OpenAI. In local
+    development the key is loaded from a `.env` file. In production the
+    container expects the `OPENAI_API_KEY` environment variable to be set.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[OpenAIKeyResponse]
+    """
+
+    kwargs = _get_kwargs()
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    *,
+    client: Union[AuthenticatedClient, Client],
+) -> Optional[OpenAIKeyResponse]:
+    """Retrieve the OpenAI API key
+
+     Returns the API key used when communicating with OpenAI. In local
+    development the key is loaded from a `.env` file. In production the
+    container expects the `OPENAI_API_KEY` environment variable to be set.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        OpenAIKeyResponse
+    """
+
+    return sync_detailed(
+        client=client,
+    ).parsed
+
+
+async def asyncio_detailed(
+    *,
+    client: Union[AuthenticatedClient, Client],
+) -> Response[OpenAIKeyResponse]:
+    """Retrieve the OpenAI API key
+
+     Returns the API key used when communicating with OpenAI. In local
+    development the key is loaded from a `.env` file. In production the
+    container expects the `OPENAI_API_KEY` environment variable to be set.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[OpenAIKeyResponse]
+    """
+
+    kwargs = _get_kwargs()
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    *,
+    client: Union[AuthenticatedClient, Client],
+) -> Optional[OpenAIKeyResponse]:
+    """Retrieve the OpenAI API key
+
+     Returns the API key used when communicating with OpenAI. In local
+    development the key is loaded from a `.env` file. In production the
+    container expects the `OPENAI_API_KEY` environment variable to be set.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        OpenAIKeyResponse
+    """
+
+    return (
+        await asyncio_detailed(
+            client=client,
+        )
+    ).parsed

--- a/handlers/client/swift_ui_view_factory_api_client/client.py
+++ b/handlers/client/swift_ui_view_factory_api_client/client.py
@@ -1,0 +1,268 @@
+import ssl
+from typing import Any, Optional, Union
+
+import httpx
+from attrs import define, evolve, field
+
+
+@define
+class Client:
+    """A class for keeping track of data related to the API
+
+    The following are accepted as keyword arguments and will be used to construct httpx Clients internally:
+
+        ``base_url``: The base URL for the API, all requests are made to a relative path to this URL
+
+        ``cookies``: A dictionary of cookies to be sent with every request
+
+        ``headers``: A dictionary of headers to be sent with every request
+
+        ``timeout``: The maximum amount of a time a request can take. API functions will raise
+        httpx.TimeoutException if this is exceeded.
+
+        ``verify_ssl``: Whether or not to verify the SSL certificate of the API server. This should be True in production,
+        but can be set to False for testing purposes.
+
+        ``follow_redirects``: Whether or not to follow redirects. Default value is False.
+
+        ``httpx_args``: A dictionary of additional arguments to be passed to the ``httpx.Client`` and ``httpx.AsyncClient`` constructor.
+
+
+    Attributes:
+        raise_on_unexpected_status: Whether or not to raise an errors.UnexpectedStatus if the API returns a
+            status code that was not documented in the source OpenAPI document. Can also be provided as a keyword
+            argument to the constructor.
+    """
+
+    raise_on_unexpected_status: bool = field(default=False, kw_only=True)
+    _base_url: str = field(alias="base_url")
+    _cookies: dict[str, str] = field(factory=dict, kw_only=True, alias="cookies")
+    _headers: dict[str, str] = field(factory=dict, kw_only=True, alias="headers")
+    _timeout: Optional[httpx.Timeout] = field(default=None, kw_only=True, alias="timeout")
+    _verify_ssl: Union[str, bool, ssl.SSLContext] = field(default=True, kw_only=True, alias="verify_ssl")
+    _follow_redirects: bool = field(default=False, kw_only=True, alias="follow_redirects")
+    _httpx_args: dict[str, Any] = field(factory=dict, kw_only=True, alias="httpx_args")
+    _client: Optional[httpx.Client] = field(default=None, init=False)
+    _async_client: Optional[httpx.AsyncClient] = field(default=None, init=False)
+
+    def with_headers(self, headers: dict[str, str]) -> "Client":
+        """Get a new client matching this one with additional headers"""
+        if self._client is not None:
+            self._client.headers.update(headers)
+        if self._async_client is not None:
+            self._async_client.headers.update(headers)
+        return evolve(self, headers={**self._headers, **headers})
+
+    def with_cookies(self, cookies: dict[str, str]) -> "Client":
+        """Get a new client matching this one with additional cookies"""
+        if self._client is not None:
+            self._client.cookies.update(cookies)
+        if self._async_client is not None:
+            self._async_client.cookies.update(cookies)
+        return evolve(self, cookies={**self._cookies, **cookies})
+
+    def with_timeout(self, timeout: httpx.Timeout) -> "Client":
+        """Get a new client matching this one with a new timeout (in seconds)"""
+        if self._client is not None:
+            self._client.timeout = timeout
+        if self._async_client is not None:
+            self._async_client.timeout = timeout
+        return evolve(self, timeout=timeout)
+
+    def set_httpx_client(self, client: httpx.Client) -> "Client":
+        """Manually set the underlying httpx.Client
+
+        **NOTE**: This will override any other settings on the client, including cookies, headers, and timeout.
+        """
+        self._client = client
+        return self
+
+    def get_httpx_client(self) -> httpx.Client:
+        """Get the underlying httpx.Client, constructing a new one if not previously set"""
+        if self._client is None:
+            self._client = httpx.Client(
+                base_url=self._base_url,
+                cookies=self._cookies,
+                headers=self._headers,
+                timeout=self._timeout,
+                verify=self._verify_ssl,
+                follow_redirects=self._follow_redirects,
+                **self._httpx_args,
+            )
+        return self._client
+
+    def __enter__(self) -> "Client":
+        """Enter a context manager for self.client—you cannot enter twice (see httpx docs)"""
+        self.get_httpx_client().__enter__()
+        return self
+
+    def __exit__(self, *args: Any, **kwargs: Any) -> None:
+        """Exit a context manager for internal httpx.Client (see httpx docs)"""
+        self.get_httpx_client().__exit__(*args, **kwargs)
+
+    def set_async_httpx_client(self, async_client: httpx.AsyncClient) -> "Client":
+        """Manually the underlying httpx.AsyncClient
+
+        **NOTE**: This will override any other settings on the client, including cookies, headers, and timeout.
+        """
+        self._async_client = async_client
+        return self
+
+    def get_async_httpx_client(self) -> httpx.AsyncClient:
+        """Get the underlying httpx.AsyncClient, constructing a new one if not previously set"""
+        if self._async_client is None:
+            self._async_client = httpx.AsyncClient(
+                base_url=self._base_url,
+                cookies=self._cookies,
+                headers=self._headers,
+                timeout=self._timeout,
+                verify=self._verify_ssl,
+                follow_redirects=self._follow_redirects,
+                **self._httpx_args,
+            )
+        return self._async_client
+
+    async def __aenter__(self) -> "Client":
+        """Enter a context manager for underlying httpx.AsyncClient—you cannot enter twice (see httpx docs)"""
+        await self.get_async_httpx_client().__aenter__()
+        return self
+
+    async def __aexit__(self, *args: Any, **kwargs: Any) -> None:
+        """Exit a context manager for underlying httpx.AsyncClient (see httpx docs)"""
+        await self.get_async_httpx_client().__aexit__(*args, **kwargs)
+
+
+@define
+class AuthenticatedClient:
+    """A Client which has been authenticated for use on secured endpoints
+
+    The following are accepted as keyword arguments and will be used to construct httpx Clients internally:
+
+        ``base_url``: The base URL for the API, all requests are made to a relative path to this URL
+
+        ``cookies``: A dictionary of cookies to be sent with every request
+
+        ``headers``: A dictionary of headers to be sent with every request
+
+        ``timeout``: The maximum amount of a time a request can take. API functions will raise
+        httpx.TimeoutException if this is exceeded.
+
+        ``verify_ssl``: Whether or not to verify the SSL certificate of the API server. This should be True in production,
+        but can be set to False for testing purposes.
+
+        ``follow_redirects``: Whether or not to follow redirects. Default value is False.
+
+        ``httpx_args``: A dictionary of additional arguments to be passed to the ``httpx.Client`` and ``httpx.AsyncClient`` constructor.
+
+
+    Attributes:
+        raise_on_unexpected_status: Whether or not to raise an errors.UnexpectedStatus if the API returns a
+            status code that was not documented in the source OpenAPI document. Can also be provided as a keyword
+            argument to the constructor.
+        token: The token to use for authentication
+        prefix: The prefix to use for the Authorization header
+        auth_header_name: The name of the Authorization header
+    """
+
+    raise_on_unexpected_status: bool = field(default=False, kw_only=True)
+    _base_url: str = field(alias="base_url")
+    _cookies: dict[str, str] = field(factory=dict, kw_only=True, alias="cookies")
+    _headers: dict[str, str] = field(factory=dict, kw_only=True, alias="headers")
+    _timeout: Optional[httpx.Timeout] = field(default=None, kw_only=True, alias="timeout")
+    _verify_ssl: Union[str, bool, ssl.SSLContext] = field(default=True, kw_only=True, alias="verify_ssl")
+    _follow_redirects: bool = field(default=False, kw_only=True, alias="follow_redirects")
+    _httpx_args: dict[str, Any] = field(factory=dict, kw_only=True, alias="httpx_args")
+    _client: Optional[httpx.Client] = field(default=None, init=False)
+    _async_client: Optional[httpx.AsyncClient] = field(default=None, init=False)
+
+    token: str
+    prefix: str = "Bearer"
+    auth_header_name: str = "Authorization"
+
+    def with_headers(self, headers: dict[str, str]) -> "AuthenticatedClient":
+        """Get a new client matching this one with additional headers"""
+        if self._client is not None:
+            self._client.headers.update(headers)
+        if self._async_client is not None:
+            self._async_client.headers.update(headers)
+        return evolve(self, headers={**self._headers, **headers})
+
+    def with_cookies(self, cookies: dict[str, str]) -> "AuthenticatedClient":
+        """Get a new client matching this one with additional cookies"""
+        if self._client is not None:
+            self._client.cookies.update(cookies)
+        if self._async_client is not None:
+            self._async_client.cookies.update(cookies)
+        return evolve(self, cookies={**self._cookies, **cookies})
+
+    def with_timeout(self, timeout: httpx.Timeout) -> "AuthenticatedClient":
+        """Get a new client matching this one with a new timeout (in seconds)"""
+        if self._client is not None:
+            self._client.timeout = timeout
+        if self._async_client is not None:
+            self._async_client.timeout = timeout
+        return evolve(self, timeout=timeout)
+
+    def set_httpx_client(self, client: httpx.Client) -> "AuthenticatedClient":
+        """Manually set the underlying httpx.Client
+
+        **NOTE**: This will override any other settings on the client, including cookies, headers, and timeout.
+        """
+        self._client = client
+        return self
+
+    def get_httpx_client(self) -> httpx.Client:
+        """Get the underlying httpx.Client, constructing a new one if not previously set"""
+        if self._client is None:
+            self._headers[self.auth_header_name] = f"{self.prefix} {self.token}" if self.prefix else self.token
+            self._client = httpx.Client(
+                base_url=self._base_url,
+                cookies=self._cookies,
+                headers=self._headers,
+                timeout=self._timeout,
+                verify=self._verify_ssl,
+                follow_redirects=self._follow_redirects,
+                **self._httpx_args,
+            )
+        return self._client
+
+    def __enter__(self) -> "AuthenticatedClient":
+        """Enter a context manager for self.client—you cannot enter twice (see httpx docs)"""
+        self.get_httpx_client().__enter__()
+        return self
+
+    def __exit__(self, *args: Any, **kwargs: Any) -> None:
+        """Exit a context manager for internal httpx.Client (see httpx docs)"""
+        self.get_httpx_client().__exit__(*args, **kwargs)
+
+    def set_async_httpx_client(self, async_client: httpx.AsyncClient) -> "AuthenticatedClient":
+        """Manually the underlying httpx.AsyncClient
+
+        **NOTE**: This will override any other settings on the client, including cookies, headers, and timeout.
+        """
+        self._async_client = async_client
+        return self
+
+    def get_async_httpx_client(self) -> httpx.AsyncClient:
+        """Get the underlying httpx.AsyncClient, constructing a new one if not previously set"""
+        if self._async_client is None:
+            self._headers[self.auth_header_name] = f"{self.prefix} {self.token}" if self.prefix else self.token
+            self._async_client = httpx.AsyncClient(
+                base_url=self._base_url,
+                cookies=self._cookies,
+                headers=self._headers,
+                timeout=self._timeout,
+                verify=self._verify_ssl,
+                follow_redirects=self._follow_redirects,
+                **self._httpx_args,
+            )
+        return self._async_client
+
+    async def __aenter__(self) -> "AuthenticatedClient":
+        """Enter a context manager for underlying httpx.AsyncClient—you cannot enter twice (see httpx docs)"""
+        await self.get_async_httpx_client().__aenter__()
+        return self
+
+    async def __aexit__(self, *args: Any, **kwargs: Any) -> None:
+        """Exit a context manager for underlying httpx.AsyncClient (see httpx docs)"""
+        await self.get_async_httpx_client().__aexit__(*args, **kwargs)

--- a/handlers/client/swift_ui_view_factory_api_client/errors.py
+++ b/handlers/client/swift_ui_view_factory_api_client/errors.py
@@ -1,0 +1,16 @@
+"""Contains shared errors types that can be raised from API functions"""
+
+
+class UnexpectedStatus(Exception):
+    """Raised by api functions when the response status an undocumented status and Client.raise_on_unexpected_status is True"""
+
+    def __init__(self, status_code: int, content: bytes):
+        self.status_code = status_code
+        self.content = content
+
+        super().__init__(
+            f"Unexpected status code: {status_code}\n\nResponse content:\n{content.decode(errors='ignore')}"
+        )
+
+
+__all__ = ["UnexpectedStatus"]

--- a/handlers/client/swift_ui_view_factory_api_client/models/__init__.py
+++ b/handlers/client/swift_ui_view_factory_api_client/models/__init__.py
@@ -1,0 +1,23 @@
+"""Contains all the data models used in inputs/outputs"""
+
+from .error_response import ErrorResponse
+from .generate_swift_ui_view_body import GenerateSwiftUIViewBody
+from .generate_swift_ui_view_body_style import GenerateSwiftUIViewBodyStyle
+from .generate_swift_ui_view_response_200 import GenerateSwiftUIViewResponse200
+from .interpret_layout_body import InterpretLayoutBody
+from .layout_interpretation_response import LayoutInterpretationResponse
+from .layout_node import LayoutNode
+from .layout_node_type import LayoutNodeType
+from .open_ai_key_response import OpenAIKeyResponse
+
+__all__ = (
+    "ErrorResponse",
+    "GenerateSwiftUIViewBody",
+    "GenerateSwiftUIViewBodyStyle",
+    "GenerateSwiftUIViewResponse200",
+    "InterpretLayoutBody",
+    "LayoutInterpretationResponse",
+    "LayoutNode",
+    "LayoutNodeType",
+    "OpenAIKeyResponse",
+)

--- a/handlers/client/swift_ui_view_factory_api_client/models/error_response.py
+++ b/handlers/client/swift_ui_view_factory_api_client/models/error_response.py
@@ -1,0 +1,109 @@
+from collections.abc import Mapping
+from typing import Any, TypeVar, Union, cast
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..types import UNSET, Unset
+
+T = TypeVar("T", bound="ErrorResponse")
+
+
+@_attrs_define
+class ErrorResponse:
+    """
+    Attributes:
+        code (str):  Example: validation_error.
+        message (str):  Example: One or more fields are invalid..
+        detail (Union[None, Unset, str]):
+        log (Union[None, Unset, str]): Raw communication log if available
+    """
+
+    code: str
+    message: str
+    detail: Union[None, Unset, str] = UNSET
+    log: Union[None, Unset, str] = UNSET
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        code = self.code
+
+        message = self.message
+
+        detail: Union[None, Unset, str]
+        if isinstance(self.detail, Unset):
+            detail = UNSET
+        else:
+            detail = self.detail
+
+        log: Union[None, Unset, str]
+        if isinstance(self.log, Unset):
+            log = UNSET
+        else:
+            log = self.log
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "code": code,
+                "message": message,
+            }
+        )
+        if detail is not UNSET:
+            field_dict["detail"] = detail
+        if log is not UNSET:
+            field_dict["log"] = log
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        code = d.pop("code")
+
+        message = d.pop("message")
+
+        def _parse_detail(data: object) -> Union[None, Unset, str]:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(Union[None, Unset, str], data)
+
+        detail = _parse_detail(d.pop("detail", UNSET))
+
+        def _parse_log(data: object) -> Union[None, Unset, str]:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(Union[None, Unset, str], data)
+
+        log = _parse_log(d.pop("log", UNSET))
+
+        error_response = cls(
+            code=code,
+            message=message,
+            detail=detail,
+            log=log,
+        )
+
+        error_response.additional_properties = d
+        return error_response
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/handlers/client/swift_ui_view_factory_api_client/models/generate_swift_ui_view_body.py
+++ b/handlers/client/swift_ui_view_factory_api_client/models/generate_swift_ui_view_body.py
@@ -1,0 +1,111 @@
+from collections.abc import Mapping
+from typing import TYPE_CHECKING, Any, TypeVar, Union
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..types import UNSET, Unset
+
+if TYPE_CHECKING:
+    from ..models.generate_swift_ui_view_body_style import GenerateSwiftUIViewBodyStyle
+    from ..models.layout_node import LayoutNode
+
+
+T = TypeVar("T", bound="GenerateSwiftUIViewBody")
+
+
+@_attrs_define
+class GenerateSwiftUIViewBody:
+    """
+    Attributes:
+        layout (Union[Unset, LayoutNode]):  Example: {'type': 'VStack', 'children': [{'type': 'Text', 'text':
+            'Hello'}]}.
+        name (Union[Unset, str]): Optional name for the generated SwiftUI view (e.g., HomeView)
+        style (Union[Unset, GenerateSwiftUIViewBodyStyle]):
+        backend_hooks (Union[Unset, bool]): If true, the generated SwiftUI view includes an `.onAppear`
+            block where analytics or network logic can be invoked.
+             Default: False.
+    """
+
+    layout: Union[Unset, "LayoutNode"] = UNSET
+    name: Union[Unset, str] = UNSET
+    style: Union[Unset, "GenerateSwiftUIViewBodyStyle"] = UNSET
+    backend_hooks: Union[Unset, bool] = False
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        layout: Union[Unset, dict[str, Any]] = UNSET
+        if not isinstance(self.layout, Unset):
+            layout = self.layout.to_dict()
+
+        name = self.name
+
+        style: Union[Unset, dict[str, Any]] = UNSET
+        if not isinstance(self.style, Unset):
+            style = self.style.to_dict()
+
+        backend_hooks = self.backend_hooks
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update({})
+        if layout is not UNSET:
+            field_dict["layout"] = layout
+        if name is not UNSET:
+            field_dict["name"] = name
+        if style is not UNSET:
+            field_dict["style"] = style
+        if backend_hooks is not UNSET:
+            field_dict["backend_hooks"] = backend_hooks
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        from ..models.generate_swift_ui_view_body_style import GenerateSwiftUIViewBodyStyle
+        from ..models.layout_node import LayoutNode
+
+        d = dict(src_dict)
+        _layout = d.pop("layout", UNSET)
+        layout: Union[Unset, LayoutNode]
+        if isinstance(_layout, Unset):
+            layout = UNSET
+        else:
+            layout = LayoutNode.from_dict(_layout)
+
+        name = d.pop("name", UNSET)
+
+        _style = d.pop("style", UNSET)
+        style: Union[Unset, GenerateSwiftUIViewBodyStyle]
+        if isinstance(_style, Unset):
+            style = UNSET
+        else:
+            style = GenerateSwiftUIViewBodyStyle.from_dict(_style)
+
+        backend_hooks = d.pop("backend_hooks", UNSET)
+
+        generate_swift_ui_view_body = cls(
+            layout=layout,
+            name=name,
+            style=style,
+            backend_hooks=backend_hooks,
+        )
+
+        generate_swift_ui_view_body.additional_properties = d
+        return generate_swift_ui_view_body
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/handlers/client/swift_ui_view_factory_api_client/models/generate_swift_ui_view_body_style.py
+++ b/handlers/client/swift_ui_view_factory_api_client/models/generate_swift_ui_view_body_style.py
@@ -1,0 +1,140 @@
+from collections.abc import Mapping
+from typing import Any, TypeVar, Union
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..types import UNSET, Unset
+
+T = TypeVar("T", bound="GenerateSwiftUIViewBodyStyle")
+
+
+@_attrs_define
+class GenerateSwiftUIViewBodyStyle:
+    """
+    Attributes:
+        indent (Union[Unset, int]):  Default: 2.
+        header_comment (Union[Unset, bool]):  Default: True.
+        font (Union[Unset, str]): Font applied to Text and Button views
+        color (Union[Unset, str]): Foreground color name
+        spacing (Union[Unset, int]): Spacing value for stacks
+        bold (Union[Unset, bool]): Apply bold styling to Text and Button views
+        italic (Union[Unset, bool]): Apply italic styling to Text and Button views
+        padding (Union[Unset, int]): Padding value applied to leaf views
+        background_color (Union[Unset, str]): Background color name
+        corner_radius (Union[Unset, int]): Corner radius for leaf views
+    """
+
+    indent: Union[Unset, int] = 2
+    header_comment: Union[Unset, bool] = True
+    font: Union[Unset, str] = UNSET
+    color: Union[Unset, str] = UNSET
+    spacing: Union[Unset, int] = UNSET
+    bold: Union[Unset, bool] = UNSET
+    italic: Union[Unset, bool] = UNSET
+    padding: Union[Unset, int] = UNSET
+    background_color: Union[Unset, str] = UNSET
+    corner_radius: Union[Unset, int] = UNSET
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        indent = self.indent
+
+        header_comment = self.header_comment
+
+        font = self.font
+
+        color = self.color
+
+        spacing = self.spacing
+
+        bold = self.bold
+
+        italic = self.italic
+
+        padding = self.padding
+
+        background_color = self.background_color
+
+        corner_radius = self.corner_radius
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update({})
+        if indent is not UNSET:
+            field_dict["indent"] = indent
+        if header_comment is not UNSET:
+            field_dict["header_comment"] = header_comment
+        if font is not UNSET:
+            field_dict["font"] = font
+        if color is not UNSET:
+            field_dict["color"] = color
+        if spacing is not UNSET:
+            field_dict["spacing"] = spacing
+        if bold is not UNSET:
+            field_dict["bold"] = bold
+        if italic is not UNSET:
+            field_dict["italic"] = italic
+        if padding is not UNSET:
+            field_dict["padding"] = padding
+        if background_color is not UNSET:
+            field_dict["background_color"] = background_color
+        if corner_radius is not UNSET:
+            field_dict["corner_radius"] = corner_radius
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        indent = d.pop("indent", UNSET)
+
+        header_comment = d.pop("header_comment", UNSET)
+
+        font = d.pop("font", UNSET)
+
+        color = d.pop("color", UNSET)
+
+        spacing = d.pop("spacing", UNSET)
+
+        bold = d.pop("bold", UNSET)
+
+        italic = d.pop("italic", UNSET)
+
+        padding = d.pop("padding", UNSET)
+
+        background_color = d.pop("background_color", UNSET)
+
+        corner_radius = d.pop("corner_radius", UNSET)
+
+        generate_swift_ui_view_body_style = cls(
+            indent=indent,
+            header_comment=header_comment,
+            font=font,
+            color=color,
+            spacing=spacing,
+            bold=bold,
+            italic=italic,
+            padding=padding,
+            background_color=background_color,
+            corner_radius=corner_radius,
+        )
+
+        generate_swift_ui_view_body_style.additional_properties = d
+        return generate_swift_ui_view_body_style
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/handlers/client/swift_ui_view_factory_api_client/models/generate_swift_ui_view_response_200.py
+++ b/handlers/client/swift_ui_view_factory_api_client/models/generate_swift_ui_view_response_200.py
@@ -1,0 +1,64 @@
+from collections.abc import Mapping
+from typing import Any, TypeVar, Union
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..types import UNSET, Unset
+
+T = TypeVar("T", bound="GenerateSwiftUIViewResponse200")
+
+
+@_attrs_define
+class GenerateSwiftUIViewResponse200:
+    """
+    Attributes:
+        swift (Union[Unset, str]):  Example: struct GeneratedView: View {
+                var body: some View {
+                    Text("Hello")
+                }
+            }
+            .
+    """
+
+    swift: Union[Unset, str] = UNSET
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        swift = self.swift
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update({})
+        if swift is not UNSET:
+            field_dict["swift"] = swift
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        swift = d.pop("swift", UNSET)
+
+        generate_swift_ui_view_response_200 = cls(
+            swift=swift,
+        )
+
+        generate_swift_ui_view_response_200.additional_properties = d
+        return generate_swift_ui_view_response_200
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/handlers/client/swift_ui_view_factory_api_client/models/interpret_layout_body.py
+++ b/handlers/client/swift_ui_view_factory_api_client/models/interpret_layout_body.py
@@ -1,0 +1,79 @@
+from collections.abc import Mapping
+from io import BytesIO
+from typing import Any, TypeVar, Union
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from .. import types
+from ..types import UNSET, File, FileTypes, Unset
+
+T = TypeVar("T", bound="InterpretLayoutBody")
+
+
+@_attrs_define
+class InterpretLayoutBody:
+    """
+    Attributes:
+        file (Union[Unset, File]):
+    """
+
+    file: Union[Unset, File] = UNSET
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        file: Union[Unset, FileTypes] = UNSET
+        if not isinstance(self.file, Unset):
+            file = self.file.to_tuple()
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update({})
+        if file is not UNSET:
+            field_dict["file"] = file
+
+        return field_dict
+
+    def to_multipart(self) -> types.RequestFiles:
+        files: types.RequestFiles = []
+
+        if not isinstance(self.file, Unset):
+            files.append(("file", self.file.to_tuple()))
+
+        for prop_name, prop in self.additional_properties.items():
+            files.append((prop_name, (None, str(prop).encode(), "text/plain")))
+
+        return files
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        _file = d.pop("file", UNSET)
+        file: Union[Unset, File]
+        if isinstance(_file, Unset):
+            file = UNSET
+        else:
+            file = File(payload=BytesIO(_file))
+
+        interpret_layout_body = cls(
+            file=file,
+        )
+
+        interpret_layout_body.additional_properties = d
+        return interpret_layout_body
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/handlers/client/swift_ui_view_factory_api_client/models/layout_interpretation_response.py
+++ b/handlers/client/swift_ui_view_factory_api_client/models/layout_interpretation_response.py
@@ -1,0 +1,98 @@
+from collections.abc import Mapping
+from typing import TYPE_CHECKING, Any, TypeVar, Union
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..types import UNSET, Unset
+
+if TYPE_CHECKING:
+    from ..models.layout_node import LayoutNode
+
+
+T = TypeVar("T", bound="LayoutInterpretationResponse")
+
+
+@_attrs_define
+class LayoutInterpretationResponse:
+    """
+    Example:
+        {'structured': {'type': 'VStack', 'children': [{'type': 'Text', 'text': 'Hello'}]}, 'description': 'Simple
+            VStack with Hello text', 'version': 'layout-v1'}
+
+    Attributes:
+        structured (LayoutNode):  Example: {'type': 'VStack', 'children': [{'type': 'Text', 'text': 'Hello'}]}.
+        description (Union[Unset, str]): Optional natural language summary
+        version (Union[Unset, str]):  Example: layout-v1.
+        log (Union[Unset, str]): Raw communication log between the service and OpenAI
+    """
+
+    structured: "LayoutNode"
+    description: Union[Unset, str] = UNSET
+    version: Union[Unset, str] = UNSET
+    log: Union[Unset, str] = UNSET
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        structured = self.structured.to_dict()
+
+        description = self.description
+
+        version = self.version
+
+        log = self.log
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "structured": structured,
+            }
+        )
+        if description is not UNSET:
+            field_dict["description"] = description
+        if version is not UNSET:
+            field_dict["version"] = version
+        if log is not UNSET:
+            field_dict["log"] = log
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        from ..models.layout_node import LayoutNode
+
+        d = dict(src_dict)
+        structured = LayoutNode.from_dict(d.pop("structured"))
+
+        description = d.pop("description", UNSET)
+
+        version = d.pop("version", UNSET)
+
+        log = d.pop("log", UNSET)
+
+        layout_interpretation_response = cls(
+            structured=structured,
+            description=description,
+            version=version,
+            log=log,
+        )
+
+        layout_interpretation_response.additional_properties = d
+        return layout_interpretation_response
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/handlers/client/swift_ui_view_factory_api_client/models/layout_node.py
+++ b/handlers/client/swift_ui_view_factory_api_client/models/layout_node.py
@@ -1,0 +1,226 @@
+from collections.abc import Mapping
+from typing import Any, TypeVar, Union, cast
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..models.layout_node_type import LayoutNodeType
+from ..types import UNSET, Unset
+
+T = TypeVar("T", bound="LayoutNode")
+
+
+@_attrs_define
+class LayoutNode:
+    """
+    Example:
+        {'type': 'VStack', 'children': [{'type': 'Text', 'text': 'Hello'}]}
+
+    Attributes:
+        type_ (LayoutNodeType): SwiftUI component type
+        id (Union[Unset, str]): A unique node identifier
+        role (Union[None, Unset, str]): Semantic role (e.g., "header", "submit")
+        tag (Union[None, Unset, str]): Developer hint or custom logic
+        text (Union[None, Unset, str]):
+        children (Union[None, Unset, list['LayoutNode']]): Child layout nodes rendered inside container views. Multiple
+            entries are typically used for ``VStack``, ``HStack``, ``ZStack``, ``Form`` or ``NavigationStack`` groups.
+        condition (Union[None, Unset, str]): Condition expression controlling the branch
+        then (Union[Unset, LayoutNode]):  Example: {'type': 'VStack', 'children': [{'type': 'Text', 'text': 'Hello'}]}.
+        else_ (Union[Unset, LayoutNode]):  Example: {'type': 'VStack', 'children': [{'type': 'Text', 'text': 'Hello'}]}.
+    """
+
+    type_: LayoutNodeType
+    id: Union[Unset, str] = UNSET
+    role: Union[None, Unset, str] = UNSET
+    tag: Union[None, Unset, str] = UNSET
+    text: Union[None, Unset, str] = UNSET
+    children: Union[None, Unset, list["LayoutNode"]] = UNSET
+    condition: Union[None, Unset, str] = UNSET
+    then: Union[Unset, "LayoutNode"] = UNSET
+    else_: Union[Unset, "LayoutNode"] = UNSET
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        type_ = self.type_.value
+
+        id = self.id
+
+        role: Union[None, Unset, str]
+        if isinstance(self.role, Unset):
+            role = UNSET
+        else:
+            role = self.role
+
+        tag: Union[None, Unset, str]
+        if isinstance(self.tag, Unset):
+            tag = UNSET
+        else:
+            tag = self.tag
+
+        text: Union[None, Unset, str]
+        if isinstance(self.text, Unset):
+            text = UNSET
+        else:
+            text = self.text
+
+        children: Union[None, Unset, list[dict[str, Any]]]
+        if isinstance(self.children, Unset):
+            children = UNSET
+        elif isinstance(self.children, list):
+            children = []
+            for children_type_0_item_data in self.children:
+                children_type_0_item = children_type_0_item_data.to_dict()
+                children.append(children_type_0_item)
+
+        else:
+            children = self.children
+
+        condition: Union[None, Unset, str]
+        if isinstance(self.condition, Unset):
+            condition = UNSET
+        else:
+            condition = self.condition
+
+        then: Union[Unset, dict[str, Any]] = UNSET
+        if not isinstance(self.then, Unset):
+            then = self.then.to_dict()
+
+        else_: Union[Unset, dict[str, Any]] = UNSET
+        if not isinstance(self.else_, Unset):
+            else_ = self.else_.to_dict()
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "type": type_,
+            }
+        )
+        if id is not UNSET:
+            field_dict["id"] = id
+        if role is not UNSET:
+            field_dict["role"] = role
+        if tag is not UNSET:
+            field_dict["tag"] = tag
+        if text is not UNSET:
+            field_dict["text"] = text
+        if children is not UNSET:
+            field_dict["children"] = children
+        if condition is not UNSET:
+            field_dict["condition"] = condition
+        if then is not UNSET:
+            field_dict["then"] = then
+        if else_ is not UNSET:
+            field_dict["else"] = else_
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        type_ = LayoutNodeType(d.pop("type"))
+
+        id = d.pop("id", UNSET)
+
+        def _parse_role(data: object) -> Union[None, Unset, str]:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(Union[None, Unset, str], data)
+
+        role = _parse_role(d.pop("role", UNSET))
+
+        def _parse_tag(data: object) -> Union[None, Unset, str]:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(Union[None, Unset, str], data)
+
+        tag = _parse_tag(d.pop("tag", UNSET))
+
+        def _parse_text(data: object) -> Union[None, Unset, str]:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(Union[None, Unset, str], data)
+
+        text = _parse_text(d.pop("text", UNSET))
+
+        def _parse_children(data: object) -> Union[None, Unset, list["LayoutNode"]]:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            try:
+                if not isinstance(data, list):
+                    raise TypeError()
+                children_type_0 = []
+                _children_type_0 = data
+                for children_type_0_item_data in _children_type_0:
+                    children_type_0_item = LayoutNode.from_dict(children_type_0_item_data)
+
+                    children_type_0.append(children_type_0_item)
+
+                return children_type_0
+            except:  # noqa: E722
+                pass
+            return cast(Union[None, Unset, list["LayoutNode"]], data)
+
+        children = _parse_children(d.pop("children", UNSET))
+
+        def _parse_condition(data: object) -> Union[None, Unset, str]:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(Union[None, Unset, str], data)
+
+        condition = _parse_condition(d.pop("condition", UNSET))
+
+        _then = d.pop("then", UNSET)
+        then: Union[Unset, LayoutNode]
+        if isinstance(_then, Unset):
+            then = UNSET
+        else:
+            then = LayoutNode.from_dict(_then)
+
+        _else_ = d.pop("else", UNSET)
+        else_: Union[Unset, LayoutNode]
+        if isinstance(_else_, Unset):
+            else_ = UNSET
+        else:
+            else_ = LayoutNode.from_dict(_else_)
+
+        layout_node = cls(
+            type_=type_,
+            id=id,
+            role=role,
+            tag=tag,
+            text=text,
+            children=children,
+            condition=condition,
+            then=then,
+            else_=else_,
+        )
+
+        layout_node.additional_properties = d
+        return layout_node
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/handlers/client/swift_ui_view_factory_api_client/models/layout_node_type.py
+++ b/handlers/client/swift_ui_view_factory_api_client/models/layout_node_type.py
@@ -1,0 +1,21 @@
+from enum import Enum
+
+
+class LayoutNodeType(str, Enum):
+    BUTTON = "Button"
+    CONDITIONAL = "Conditional"
+    FORM = "Form"
+    HSTACK = "HStack"
+    IMAGE = "Image"
+    LIST = "List"
+    NAVIGATIONSTACK = "NavigationStack"
+    SCROLLVIEW = "ScrollView"
+    SECTION = "Section"
+    SPACER = "Spacer"
+    TEXT = "Text"
+    TEXTFIELD = "TextField"
+    VSTACK = "VStack"
+    ZSTACK = "ZStack"
+
+    def __str__(self) -> str:
+        return str(self.value)

--- a/handlers/client/swift_ui_view_factory_api_client/models/open_ai_key_response.py
+++ b/handlers/client/swift_ui_view_factory_api_client/models/open_ai_key_response.py
@@ -1,0 +1,59 @@
+from collections.abc import Mapping
+from typing import Any, TypeVar
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+T = TypeVar("T", bound="OpenAIKeyResponse")
+
+
+@_attrs_define
+class OpenAIKeyResponse:
+    """
+    Attributes:
+        api_key (str):  Example: sk-abc123.
+    """
+
+    api_key: str
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        api_key = self.api_key
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "api_key": api_key,
+            }
+        )
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        api_key = d.pop("api_key")
+
+        open_ai_key_response = cls(
+            api_key=api_key,
+        )
+
+        open_ai_key_response.additional_properties = d
+        return open_ai_key_response
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/handlers/client/swift_ui_view_factory_api_client/py.typed
+++ b/handlers/client/swift_ui_view_factory_api_client/py.typed
@@ -1,0 +1,1 @@
+# Marker file for PEP 561

--- a/handlers/client/swift_ui_view_factory_api_client/types.py
+++ b/handlers/client/swift_ui_view_factory_api_client/types.py
@@ -1,0 +1,54 @@
+"""Contains some shared types for properties"""
+
+from collections.abc import Mapping, MutableMapping
+from http import HTTPStatus
+from typing import IO, BinaryIO, Generic, Literal, Optional, TypeVar, Union
+
+from attrs import define
+
+
+class Unset:
+    def __bool__(self) -> Literal[False]:
+        return False
+
+
+UNSET: Unset = Unset()
+
+# The types that `httpx.Client(files=)` can accept, copied from that library.
+FileContent = Union[IO[bytes], bytes, str]
+FileTypes = Union[
+    # (filename, file (or bytes), content_type)
+    tuple[Optional[str], FileContent, Optional[str]],
+    # (filename, file (or bytes), content_type, headers)
+    tuple[Optional[str], FileContent, Optional[str], Mapping[str, str]],
+]
+RequestFiles = list[tuple[str, FileTypes]]
+
+
+@define
+class File:
+    """Contains information for file uploads"""
+
+    payload: BinaryIO
+    file_name: Optional[str] = None
+    mime_type: Optional[str] = None
+
+    def to_tuple(self) -> FileTypes:
+        """Return a tuple representation that httpx will accept for multipart/form-data"""
+        return self.file_name, self.payload, self.mime_type
+
+
+T = TypeVar("T")
+
+
+@define
+class Response(Generic[T]):
+    """A response from an endpoint"""
+
+    status_code: HTTPStatus
+    content: bytes
+    headers: MutableMapping[str, str]
+    parsed: Optional[T]
+
+
+__all__ = ["UNSET", "File", "FileTypes", "RequestFiles", "Response", "Unset"]

--- a/handlers/generateSwiftUIView.py
+++ b/handlers/generateSwiftUIView.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python3
+import os
+import sys
+import json
+import yaml
+
+from client.swift_ui_view_factory_api_client import Client
+from client.swift_ui_view_factory_api_client.models import GenerateSwiftUIViewBody
+from client.swift_ui_view_factory_api_client.api.factory import generate_swift_ui_view
+from client.swift_ui_view_factory_api_client.models.error_response import ErrorResponse
+
+request_file = sys.argv[1]
+log_dir = sys.argv[2]
+
+with open(request_file) as f:
+    data = yaml.safe_load(f)
+
+spec = data.get('spec', {})
+
+base_url = os.getenv('API_BASE_URL', 'http://localhost:8000')
+client = Client(base_url=base_url)
+
+response_file = os.path.join(log_dir, 'generateSwiftUIView_response.json')
+status_file = os.path.join(log_dir, 'status.yml')
+
+try:
+    body = GenerateSwiftUIViewBody.from_dict(spec)
+    resp = generate_swift_ui_view.sync(client=client, body=body)
+    with open(response_file, 'w') as f:
+        json.dump(resp.to_dict() if hasattr(resp, 'to_dict') else None, f, indent=2)
+    if resp is not None and not isinstance(resp, ErrorResponse):
+        status = 'success'
+    else:
+        status = 'failure'
+except Exception as e:
+    with open(os.path.join(log_dir, 'error.log'), 'w') as f:
+        f.write(str(e))
+    status = 'error'
+
+with open(status_file, 'w') as f:
+    f.write(f'status: {status}\n')

--- a/handlers/getOpenAIKey.py
+++ b/handlers/getOpenAIKey.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python3
+import os
+import sys
+import json
+
+from client.swift_ui_view_factory_api_client import Client
+from client.swift_ui_view_factory_api_client.api.secrets import get_open_ai_key
+
+request_file = sys.argv[1]
+log_dir = sys.argv[2]
+
+base_url = os.getenv('API_BASE_URL', 'http://localhost:8000')
+client = Client(base_url=base_url)
+
+response_file = os.path.join(log_dir, 'getOpenAIKey_response.json')
+status_file = os.path.join(log_dir, 'status.yml')
+
+try:
+    resp = get_open_ai_key.sync(client=client)
+    with open(response_file, 'w') as f:
+        json.dump(resp.to_dict() if hasattr(resp, 'to_dict') else None, f, indent=2)
+    status = 'success'
+except Exception as e:
+    with open(os.path.join(log_dir, 'error.log'), 'w') as f:
+        f.write(str(e))
+    status = 'error'
+
+with open(status_file, 'w') as f:
+    f.write(f'status: {status}\n')

--- a/handlers/index.yml
+++ b/handlers/index.yml
@@ -1,5 +1,5 @@
 deploy: handlers/deploy.sh
 backup: handlers/backup.py
-interpret: handlers/interpret.py
-generate: handlers/generate.py
-secret: handlers/secret.py
+interpretLayout: handlers/interpretLayout.py
+generateSwiftUIView: handlers/generateSwiftUIView.py
+getOpenAIKey: handlers/getOpenAIKey.py

--- a/handlers/interpretLayout.py
+++ b/handlers/interpretLayout.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python3
+import os
+import sys
+import json
+import yaml
+from pathlib import Path
+
+from client.swift_ui_view_factory_api_client import Client
+from client.swift_ui_view_factory_api_client.models import InterpretLayoutBody, File
+from client.swift_ui_view_factory_api_client.api.factory import interpret_layout
+from client.swift_ui_view_factory_api_client.models.error_response import ErrorResponse
+
+request_file = sys.argv[1]
+log_dir = sys.argv[2]
+
+with open(request_file) as f:
+    data = yaml.safe_load(f)
+
+spec = data.get('spec', {})
+file_path = spec.get('file')
+
+base_url = os.getenv('API_BASE_URL', 'http://localhost:8000')
+client = Client(base_url=base_url)
+
+response_file = os.path.join(log_dir, 'interpretLayout_response.json')
+status_file = os.path.join(log_dir, 'status.yml')
+
+try:
+    with open(file_path, 'rb') as fp:
+        body = InterpretLayoutBody(file=File(payload=fp, file_name=Path(file_path).name))
+        resp = interpret_layout.sync(client=client, body=body)
+    with open(response_file, 'w') as f:
+        json.dump(resp.to_dict() if hasattr(resp, 'to_dict') else None, f, indent=2)
+    if resp is not None and not isinstance(resp, ErrorResponse):
+        status = 'success'
+    else:
+        status = 'failure'
+except Exception as e:
+    with open(os.path.join(log_dir, 'error.log'), 'w') as f:
+        f.write(str(e))
+    status = 'error'
+
+with open(status_file, 'w') as f:
+    f.write(f'status: {status}\n')


### PR DESCRIPTION
## Summary
- generate an OpenAPI client for the SwiftUI View Factory
- implement new handlers using the generated client
- update `handlers/index.yml` to use operationId-based names
- document the new convention in handler docs

## Testing
- `scripts/dispatch.sh --selftest`

------
https://chatgpt.com/codex/tasks/task_e_686800161ff8832580137225f5284c01