### PR TITLE
Add image upload handler

### DIFF
--- a/README.codex.md
+++ b/README.codex.md
@@ -11,6 +11,7 @@ This repository follows the blueprint described in `STRUCTURE_PLAN.md`. The goal
 ├── requests/           # Inbox for Codex-written request files
 ├── processed/          # Archive for handled requests
 ├── logs/               # Structured execution logs
+├── image-upload/       # Mockup images consumed by the factory
 ├── scripts/            # Dispatcher and helper scripts
 ├── handlers/           # Individual request handlers
 ├── codex.repo.yaml     # Orchestration contract
@@ -57,8 +58,9 @@ For more details, see `docs/dispatcher_right.pdf` and `docs/how-codex-acts-like-
 1. The directories above are present in Git with `.gitkeep` files. No setup is required.
 2. Run `scripts/dispatch.sh` on the execution host to process requests. The script should watch `requests/` and place logs in `logs/`.
 3. Codex writes request YAML files to `requests/` and later reads log files from `logs/`.
-4. Add new handlers under `handlers/` and update `handlers/index.yml` to register them.
-5. Adjust `codex.repo.yaml` if the orchestration paths or policies change.
+4. Place UI mockup images in `image-upload/` and create a request with `kind: processImageUploads` to interpret them.
+5. Add new handlers under `handlers/` and update `handlers/index.yml` to register them.
+6. Adjust `codex.repo.yaml` if the orchestration paths or policies change.
 See `docs/USAGE.md` for a step-by-step overview.
 
 ## References

--- a/handlers/index.yml
+++ b/handlers/index.yml
@@ -3,3 +3,4 @@ backup: handlers/backup.py
 interpretLayoutV13: handlers/interpretLayoutV13.py
 generateSwiftUIView: handlers/generateSwiftUIView.py
 getOpenAIKey: handlers/getOpenAIKey.py
+processImageUploads: handlers/processImageUploads.py

--- a/handlers/processImageUploads.py
+++ b/handlers/processImageUploads.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+"""Process images in the image-upload directory and send them to the OpenAI API.
+
+This handler collects all image files under ``image-upload/`` in chronological
+order and submits them to the vision model. The final response from the model is
+saved so other handlers can consume it as the last reply of the model.
+"""
+import os
+import sys
+import json
+import base64
+import yaml
+import openai
+
+UPLOAD_DIR = os.path.join(os.path.dirname(__file__), '..', 'image-upload')
+
+
+def list_images(path: str) -> list[str]:
+    """Return a sorted list of image paths by modification time."""
+    supported = ('.png', '.jpg', '.jpeg')
+    images = [os.path.join(path, f) for f in os.listdir(path)
+              if f.lower().endswith(supported)]
+    images.sort(key=lambda p: os.path.getmtime(p))
+    return images
+
+
+def encode_image(path: str) -> str:
+    with open(path, 'rb') as f:
+        return base64.b64encode(f.read()).decode('utf-8')
+
+
+if __name__ == '__main__':
+    request_file = sys.argv[1]
+    log_dir = sys.argv[2]
+
+    with open(request_file) as f:
+        data = yaml.safe_load(f)
+
+    spec = data.get('spec', {})
+    model = spec.get('gpt_model', 'gpt-4o')
+
+    response_file = os.path.join(log_dir, 'processImageUploads_response.json')
+    status_file = os.path.join(log_dir, 'status.yml')
+
+    try:
+        openai.api_key = os.getenv('OPENAI_API_KEY')
+        images = list_images(UPLOAD_DIR)
+        if not images:
+            raise FileNotFoundError('No images found in image-upload directory')
+
+        contents = [
+            {"type": "text", "text": "Interpret these mockups chronologically."}
+        ]
+        for path in images:
+            contents.append({
+                "type": "image_url",
+                "image_url": {"url": f"data:image/png;base64,{encode_image(path)}"}
+            })
+
+        messages = [
+            {
+                "role": "system",
+                "content": (
+                    "You are the SwiftUI View factory. Given a series of UI "
+                    "mockups, return the best SwiftUI view code as JSON with "
+                    "keys 'swift' and 'description'."
+                ),
+            },
+            {"role": "user", "content": contents},
+        ]
+
+        resp = openai.ChatCompletion.create(model=model, messages=messages)
+        result = {
+            "reply": resp.choices[0].message.content.strip(),
+            "log": json.dumps(resp, default=str),
+        }
+        with open(response_file, 'w') as f:
+            json.dump(result, f, indent=2)
+        status = 'success'
+    except Exception as e:
+        with open(os.path.join(log_dir, 'error.log'), 'w') as f:
+            f.write(str(e))
+        status = 'error'
+
+    with open(status_file, 'w') as f:
+        f.write(f'status: {status}\n')


### PR DESCRIPTION
## Summary
- create `image-upload/` directory for mockup files
- document new directory and handler in README
- implement `handlers/processImageUploads.py` to send all uploaded images to OpenAI
- register the handler in `handlers/index.yml`

## Testing
- `scripts/dispatch.sh --selftest`

------
https://chatgpt.com/codex/tasks/task_e_68680e64040c8325a4dec8e764b79445