### PR TITLE
Add macOS Xcode build handler and docs

### DIFF
--- a/README.codex.md
+++ b/README.codex.md
@@ -68,3 +68,5 @@ See `docs/USAGE.md` for a step-by-step overview.
 - `docs/dispatcher_right.pdf` – Dispatcher checklist and design notes.
 - `docs/how-codex-acts-like-a-compiler.pdf` – Git-based orchestration model.
 - `docs/Is “How Codex Acts Like a Compiler” a Hard-Wired Demo or a Generic Repository Blueprint?.pdf` – Discussion of this repository pattern.
+
+- `docs/macos-xcode-workflow.md` – Handling Xcode builds on a macOS clone.

--- a/docs/macos-xcode-workflow.md
+++ b/docs/macos-xcode-workflow.md
@@ -1,0 +1,61 @@
+# Running Xcode Builds via Git Orchestration
+
+SwiftUI code requires Apple's proprietary toolchain to compile, which is only
+available on macOS. The repository follows a Git-driven dispatcher model where
+request files are placed under `requests/` and handler output is committed to
+`logs/`. This document explains how the same pattern works for Xcode builds.
+
+## Problem
+
+Xcode and the SwiftUI compiler are closed source and macOS-only. To get real
+compiler feedback we must run the build tools on a Mac while still using the
+Git orchestrated workflow.
+
+## Solution Strategy
+
+1. **Git-based Orchestration**
+   - Requests describing build actions are merged to `main` under `requests/`.
+   - Handler output is written to `logs/` and committed back for review.
+
+2. **Local macOS Clone with Xcode**
+   - A Mac machine with Xcode installed clones the repository and runs
+     `scripts/dispatch.sh` just like any other execution host.
+   - The dispatcher processes incoming requests and invokes macOS-specific
+     handlers.
+
+3. **Scripted Xcode Build**
+   - Handlers use `xcodebuild` (or `swift build`) to compile SwiftUI projects.
+     Build logs are captured and stored under `logs/` so the compiler output is
+     versioned in Git.
+
+4. **Managing Closed-Source Tools**
+   - Although Xcode itself is proprietary, its command-line interface can be
+     scripted. The repository does not contain Xcode; it simply triggers the
+     tools that are already installed on the Mac runner.
+
+5. **Benefits of the Git Workflow**
+   - Compiler warnings and errors are persisted in Git history.
+   - Multiple machines can reproduce builds by checking out the same commit and
+     running the dispatcher.
+
+## `buildSwiftProject` Handler
+
+A new handler `handlers/buildSwiftProject.py` encapsulates the Xcode invocation.
+Requests of `kind: buildSwiftProject` should include a `spec` section with
+optional fields:
+
+```yaml
+kind: buildSwiftProject
+spec:
+  workspace: MyApp.xcworkspace   # optional
+  project: MyApp.xcodeproj       # optional if workspace is used
+  scheme: MyApp                  # Xcode scheme to build
+  sdk: macosx                    # or iphonesimulator
+  destination: 'generic/platform=macOS'  # passed to xcodebuild
+```
+
+The handler composes the appropriate `xcodebuild` command and writes
+`xcodebuild.log` and `status.yml` in the log directory.
+
+Run the dispatcher on a Mac with Xcode installed to process such requests and
+commit the resulting build logs back to the repository.

--- a/docs/openapi-handler-implementation.md
+++ b/docs/openapi-handler-implementation.md
@@ -107,3 +107,9 @@ with open(os.path.join(log_dir, 'getOpenAIKey_response.json'), 'w') as f:
 ```
 
 All handlers require the OPENAI_API_KEY environment variable.
+
+## `handlers/buildSwiftProject.py`
+
+Runs `xcodebuild` with parameters from the request. It must be executed on
+macOS with Xcode installed. Build output is saved to `xcodebuild.log` and the
+handler reports success or failure via `status.yml`.

--- a/handlers/buildSwiftProject.py
+++ b/handlers/buildSwiftProject.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+"""Build a Swift or Xcode project using xcodebuild.
+
+This handler is intended to run on macOS with Xcode installed. It parses the
+request YAML for a `spec` block containing `workspace`, `project`, `scheme`,
+`sdk`, and `destination` fields. Any field may be omitted. The resulting build
+log is written to `xcodebuild.log` in the log directory, and `status.yml`
+records `success` or `failure`.
+"""
+import os
+import sys
+import yaml
+import subprocess
+
+request_file = sys.argv[1]
+log_dir = sys.argv[2]
+
+with open(request_file) as f:
+    data = yaml.safe_load(f)
+
+spec = data.get('spec', {})
+workspace = spec.get('workspace')
+project = spec.get('project')
+scheme = spec.get('scheme')
+sdk = spec.get('sdk')
+destination = spec.get('destination')
+
+cmd = ["xcodebuild"]
+if workspace:
+    cmd.extend(["-workspace", workspace])
+if project:
+    cmd.extend(["-project", project])
+if scheme:
+    cmd.extend(["-scheme", scheme])
+if sdk:
+    cmd.extend(["-sdk", sdk])
+if destination:
+    cmd.extend(["-destination", destination])
+
+log_file = os.path.join(log_dir, 'xcodebuild.log')
+status_file = os.path.join(log_dir, 'status.yml')
+
+os.makedirs(log_dir, exist_ok=True)
+
+with open(log_file, 'w') as lf:
+    try:
+        subprocess.check_call(cmd, stdout=lf, stderr=subprocess.STDOUT)
+        status = 'success'
+    except Exception as e:
+        lf.write(f"\nERROR: {e}\n")
+        status = 'failure'
+
+with open(status_file, 'w') as sf:
+    sf.write(f'status: {status}\n')

--- a/handlers/index.yml
+++ b/handlers/index.yml
@@ -4,3 +4,5 @@ interpretLayoutV13: handlers/interpretLayoutV13.py
 generateSwiftUIView: handlers/generateSwiftUIView.py
 getOpenAIKey: handlers/getOpenAIKey.py
 processImageUploads: handlers/processImageUploads.py
+
+buildSwiftProject: handlers/buildSwiftProject.py


### PR DESCRIPTION
## Summary
- describe how to run Xcode builds in a local macOS clone
- add new handler `buildSwiftProject.py` for scripted Xcode builds
- register the handler in `handlers/index.yml`
- document the handler in README and implementation docs

## Testing
- `scripts/dispatch.sh --selftest`

------
https://chatgpt.com/codex/tasks/task_e_6868133ee4808325b97995d65aff5e36