### PR TITLE
Add Docker wrapper for dispatcher

### DIFF
--- a/README.codex.md
+++ b/README.codex.md
@@ -71,4 +71,5 @@ See `docs/USAGE.md` for a step-by-step overview.
 
 - `docs/macos-xcode-workflow.md` – Handling Xcode builds on a macOS clone.
 - `docs/swift-package-handler.md` – Packaging generated SwiftUI files.
+- `docs/docker-runtime.md` – Running the factory in a Docker container.
 

--- a/docs/docker-runtime.md
+++ b/docs/docker-runtime.md
@@ -1,0 +1,33 @@
+# Dockerized Runtime for Cross-Platform Consistency
+
+The Python handlers in this repository rely on a specific runtime and external
+dependencies. When the dispatcher runs directly on different operating systems,
+results can vary or fail altogether.
+
+## Problem
+
+Contributors may execute the factory on Windows, macOS or Linux machines with
+varying Python versions. Some handlers also expect additional tools. These
+environment differences make it hard to reproduce results and can lead to
+execution errors.
+
+## Solution
+
+Use a Docker container to provide a known-good Python environment. The wrapper
+script `scripts/docker_dispatch.sh` locates the repository root using
+`git rev-parse` so the clone can live anywhere on the host. It mounts the root
+at `/repo` inside the container and runs `scripts/dispatch.sh` there. The
+container image defaults to `python:3.11-slim` but can be overridden with the
+`DOCKER_IMAGE` environment variable.
+
+## Usage
+
+Run the wrapper instead of `dispatch.sh`:
+
+```bash
+scripts/docker_dispatch.sh
+```
+
+Any arguments are forwarded to the dispatcher. Environment variables such as
+`OPENAI_API_KEY` are passed through so handlers behave exactly as they do on the
+host machine.

--- a/docs/openapi-handler-implementation.md
+++ b/docs/openapi-handler-implementation.md
@@ -120,3 +120,10 @@ Prepares a Swift package from loose `.swift` files and archives it as
 `<package_name>.package`. The archive can then be built on macOS using the
 `buildSwiftProject` handler.
 
+## `scripts/docker_dispatch.sh`
+
+Wraps the dispatcher in a Docker container. The script detects the repository
+root with `git rev-parse`, mounts it into a Python image and runs
+`scripts/dispatch.sh` there. Use this wrapper to ensure all Python handlers run
+with a consistent runtime across operating systems.
+

--- a/scripts/docker_dispatch.sh
+++ b/scripts/docker_dispatch.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -euo pipefail
+# Locate repository root independent of invocation path
+REPO_ROOT="$(git -C "$(dirname "$0")/.." rev-parse --show-toplevel)"
+IMAGE="${DOCKER_IMAGE:-python:3.11-slim}"
+
+# Propagate relevant env vars (OPENAI_API_KEY used by handlers)
+ENV_VARS=""
+if [[ -n "${OPENAI_API_KEY:-}" ]]; then
+  ENV_VARS="-e OPENAI_API_KEY=$OPENAI_API_KEY"
+fi
+
+# Execute dispatcher inside container
+exec docker run --rm \
+    -v "$REPO_ROOT":/repo \
+    -w /repo \
+    $ENV_VARS \
+    "$IMAGE" \
+    bash scripts/dispatch.sh "$@"


### PR DESCRIPTION
## Summary
- add a script to run the dispatcher inside Docker for a consistent Python runtime
- document how the Docker wrapper works
- reference the new doc in `README.codex.md`
- mention the wrapper in the handler implementation doc

## Testing
- `scripts/dispatch.sh --selftest`
- `scripts/docker_dispatch.sh --selftest` *(fails: docker not found)*

------
https://chatgpt.com/codex/tasks/task_e_68681d310d4c8325b303472f8e2a4146