### PR TITLE
Add Swift OpenAPI client generator handler

### DIFF
--- a/README.codex.md
+++ b/README.codex.md
@@ -72,4 +72,6 @@ See `docs/USAGE.md` for a step-by-step overview.
 - `docs/macos-xcode-workflow.md` – Handling Xcode builds on a macOS clone.
 - `docs/swift-package-handler.md` – Packaging generated SwiftUI files.
 - `docs/docker-runtime.md` – Running the factory in a Docker container.
+- `docs/swift-openapi-generator.md` – Generating client packages with the
+  Swift OpenAPI Generator plugin.
 

--- a/docs/swift-openapi-generator.md
+++ b/docs/swift-openapi-generator.md
@@ -8,29 +8,25 @@ This repository can generate Swift client libraries from the API description
 - A macOS or Linux machine with the Swift toolchain installed
 - The `swift-openapi-generator` package checked out or accessible via SwiftPM
 
-## Handler Idea: `generateSwiftClient`
+## Handler: `generateSwiftClient`
 
-Add a new handler that invokes `swift-openapi-generator` and archives the
-resulting Swift package. A minimal shell script might look like:
+The repository includes a Python handler `generateSwiftClient.py` that prepares
+a Swift package using the `swift-openapi-generator` plugin. The handler copies
+`api/openapi.yml` into the target's source directory, writes a `Package.swift`
+with the required dependencies and plugin, runs `swift build` for immediate
+compiler feedback, and finally archives the directory as `<package_name>.package`.
 
-```bash
-#!/usr/bin/env bash
-set -euo pipefail
-request_file="$1"
-log_dir="$2"
+Example request:
 
-spec="api/openapi.yml"
-output_dir="$log_dir/Client"
-
-mkdir -p "$output_dir"
-
-swift run swift-openapi-generator generate "$spec" \
-  --output-directory "$output_dir"
-
-zip -r "$log_dir/SwiftClient.zip" "$output_dir"
+```yaml
+kind: generateSwiftClient
+spec:
+  package_name: HelloClient
+  module_name: HelloClient
+  generator_version: 1.6.0
 ```
 
-Register the handler in `handlers/index.yml` under a new kind such as
-`generateSwiftClient`. Dispatching a request with that kind produces a zipped
-client library ready for Xcode or further packaging.
+The build output is saved to `build.log` and `status.yml` indicates `success` or
+`failure`. The resulting package can be compiled on macOS or Linux where the
+plugin resolves the OpenAPI document during the build.
 

--- a/handlers/generateSwiftClient.py
+++ b/handlers/generateSwiftClient.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+"""Generate a Swift package using swift-openapi-generator."""
+import os
+import sys
+import yaml
+import subprocess
+import shutil
+
+request_file = sys.argv[1]
+log_dir = sys.argv[2]
+
+with open(request_file) as f:
+    data = yaml.safe_load(f)
+
+spec = data.get('spec', {})
+package_name = spec.get('package_name', 'OpenAPIClient')
+module_name = spec.get('module_name', package_name)
+openapi_path = spec.get('openapi', 'api/openapi.yml')
+generator_version = spec.get('generator_version', '1.6.0')
+runtime_version = spec.get('runtime_version', '1.7.0')
+transport_version = spec.get('transport_version', '1.0.0')
+
+package_dir = os.path.join(log_dir, package_name)
+os.makedirs(package_dir, exist_ok=True)
+
+# Initialize the Swift package
+subprocess.check_call(['swift', 'package', 'init', '--name', package_name, '--type', 'executable'], cwd=package_dir)
+
+package_swift = f"""// swift-tools-version: 6.1
+import PackageDescription
+
+let package = Package(
+    name: \"{package_name}\",
+    platforms: [.macOS(.v10_15)],
+    dependencies: [
+        .package(url: \"https://github.com/apple/swift-openapi-generator.git\", from: \"{generator_version}\"),
+        .package(url: \"https://github.com/apple/swift-openapi-runtime.git\", from: \"{runtime_version}\"),
+        .package(url: \"https://github.com/apple/swift-openapi-urlsession.git\", from: \"{transport_version}\"),
+    ],
+    targets: [
+        .executableTarget(
+            name: \"{module_name}\",
+            dependencies: [
+                .product(name: \"OpenAPIRuntime\", package: \"swift-openapi-runtime\"),
+                .product(name: \"OpenAPIURLSession\", package: \"swift-openapi-urlsession\"),
+            ],
+            plugins: [.plugin(name: \"OpenAPIGenerator\", package: \"swift-openapi-generator\")]
+        )
+    ]
+)
+"""
+
+with open(os.path.join(package_dir, 'Package.swift'), 'w') as f:
+    f.write(package_swift)
+
+# Copy OpenAPI document into the target directory so the plugin can access it
+target_dir = os.path.join(package_dir, 'Sources', module_name)
+os.makedirs(target_dir, exist_ok=True)
+shutil.copy(openapi_path, os.path.join(target_dir, 'openapi.yml'))
+
+status = 'success'
+with open(os.path.join(log_dir, 'build.log'), 'w') as build_log:
+    try:
+        subprocess.check_call(['swift', 'build'], cwd=package_dir, stdout=build_log, stderr=subprocess.STDOUT)
+    except subprocess.CalledProcessError:
+        status = 'failure'
+
+# Archive the package
+archive = os.path.join(log_dir, f"{package_name}.package")
+subprocess.check_call(['zip', '-r', archive, package_name], cwd=log_dir)
+
+with open(os.path.join(log_dir, 'status.yml'), 'w') as f:
+    f.write(f'status: {status}\n')

--- a/handlers/index.yml
+++ b/handlers/index.yml
@@ -6,4 +6,5 @@ getOpenAIKey: handlers/getOpenAIKey.py
 processImageUploads: handlers/processImageUploads.py
 buildSwiftProject: handlers/buildSwiftProject.py
 packageSwiftUIView: handlers/packageSwiftUIView.py
+generateSwiftClient: handlers/generateSwiftClient.py
 


### PR DESCRIPTION
## Summary
- implement `generateSwiftClient.py` handler to create a Swift package that uses `swift-openapi-generator`
- register the new handler in `handlers/index.yml`
- document usage of the handler and include reference in the main README

## Testing
- `python3 handlers/generateSwiftClient.py /tmp/request.yml /tmp/testlogs`

------
https://chatgpt.com/codex/tasks/task_e_6868daac3dd08325ab38c130dc7e580c