### PR TITLE
Add CLI test suite and execution plan

### DIFF
--- a/codex-plan.md
+++ b/codex-plan.md
@@ -1,0 +1,26 @@
+# Codex Execution Plan: SwiftUI View Factory
+
+This plan tracks major milestones for the Codex-managed SwiftUI View Factory.
+It mirrors the structure of the OpenAPI kernel plan and marks completed tasks.
+
+---
+
+## 🪪 Phase 0 · Repository Identity
+- [x] Provide `codex.repo.yaml` describing the orchestration contract.
+- [x] Document repository layout in `README.codex.md`.
+
+---
+
+## 🧱 Phase 1 · Project Scaffolding
+- [x] Set up dispatcher script under `scripts/dispatch.sh`.
+- [x] Add `handlers/` with registry `handlers/index.yml`.
+- [x] Include example handlers like `deploy.sh`.
+
+---
+
+## 🧪 Phase 6 · Testing & Validation
+- [x] Add CLI self-test option.
+- [x] Test the CLI with fixtures.
+- [ ] Simulate HTTP requests directly to handlers in unit tests.
+
+---

--- a/tests/fixtures/deploy_request.yml
+++ b/tests/fixtures/deploy_request.yml
@@ -1,0 +1,3 @@
+kind: deploy
+spec:
+  target: test

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,53 @@
+import subprocess
+import uuid
+import shutil
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+DISPATCH = REPO_ROOT / "scripts" / "dispatch.sh"
+
+
+def _run_cli(*args):
+    return subprocess.run(
+        [str(DISPATCH), *args],
+        cwd=REPO_ROOT,
+        text=True,
+        capture_output=True,
+        check=True,
+    )
+
+
+def _clean_dirs():
+    for name in ("requests", "logs", "processed"):
+        p = REPO_ROOT / name
+        if p.exists():
+            shutil.rmtree(p)
+        p.mkdir()
+
+
+def test_version():
+    result = _run_cli("--version")
+    assert result.stdout.strip() == "0.1.0"
+
+
+def test_selftest():
+    result = _run_cli("--selftest")
+    assert "Dispatcher OK" in result.stdout
+
+
+def test_deploy_request():
+    _clean_dirs()
+    req_dir = REPO_ROOT / "requests"
+    fixture = REPO_ROOT / "tests" / "fixtures" / "deploy_request.yml"
+    req_file = req_dir / f"{uuid.uuid4()}.yml"
+    shutil.copyfile(fixture, req_file)
+
+    _run_cli()
+
+    assert (REPO_ROOT / "processed" / req_file.name).exists()
+    log_dir = REPO_ROOT / "logs" / req_file.stem
+    expected_log = f"Deploy handler executed for requests/{req_file.name}"
+    assert (log_dir / "deploy.log").read_text().strip() == expected_log
+    assert (log_dir / "status.yml").read_text().strip() == "status: success"
+
+    _clean_dirs()


### PR DESCRIPTION
## Summary
- document overall repo plan in `codex-plan.md`
- create fixture for dispatcher tests
- add pytest covering dispatcher `--version`, `--selftest`, and running a request

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686b61f0f378832593c7db13116fe009